### PR TITLE
Fixing a problem with double slashes in path to originalArtifactName

### DIFF
--- a/src/main/java/io/snyk/plugins/SnykSecurityBuilder.java
+++ b/src/main/java/io/snyk/plugins/SnykSecurityBuilder.java
@@ -269,7 +269,7 @@ public class SnykSecurityBuilder extends Builder {
 
         String artifactName = projectDirName + "_snyk_report.html";
         String artifactPath = dirPath + "/" + artifactName;
-        String originalArtifactName = "/snyk_report.html";
+        String originalArtifactName = "snyk_report.html";
         String originalArtifactPath = dirPath + "/" + originalArtifactName;
 
         Files.move(


### PR DESCRIPTION
Noticed that the current concatenated path contains two slashes.
