### PR TITLE
fix: add more logging when archiving artifacts

### DIFF
--- a/src/main/java/io/snyk/plugins/SnykSecurityBuilder.java
+++ b/src/main/java/io/snyk/plugins/SnykSecurityBuilder.java
@@ -316,10 +316,17 @@ public class SnykSecurityBuilder extends Builder {
     }
 
     private void archiveArtifacts(Run<?,?> build, Launcher launcher, TaskListener listener, FilePath workspace )
-            throws java.lang.InterruptedException {
+            throws Exception {
         ArtifactArchiver artifactArchiver = new ArtifactArchiver("*snyk_report.*");
+
+        LOG.log(FINE, format("Build root directory: [%s]", build.getRootDir()));
+        LOG.log(FINE, format("Workspace remote: [%s]", workspace.getRemote()));
+        LOG.log(FINE, format("Start archiving artifacts: [%s]", artifactArchiver.getArtifacts()));
+
         artifactArchiver.perform(build, workspace, launcher, listener);
-    };
+
+        LOG.log(FINE, "Archiving artifacts successfully completed");
+    }
 
     @Extension
     public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {


### PR DESCRIPTION
Add more debug output when we archiving artifacts to a master node.