### PR TITLE
feat: snyk credential type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>symbol-annotation</artifactId>
-      <version>1.10</version>
+      <version>1.7</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,11 @@
       <artifactId>symbol-annotation</artifactId>
       <version>1.10</version>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+      <version>2.1.18</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/io/snyk/jenkins/credentials/DefaultSnykApiToken.java
+++ b/src/main/java/io/snyk/jenkins/credentials/DefaultSnykApiToken.java
@@ -1,0 +1,43 @@
+package io.snyk.jenkins.credentials;
+
+import javax.annotation.Nonnull;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import hudson.Extension;
+import hudson.util.Secret;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import static hudson.util.Secret.fromString;
+
+/**
+ * Default implementation of {@link SnykApiToken} for use by Jenkins {@link com.cloudbees.plugins.credentials.CredentialsProvider}
+ * instances that store {@link Secret} locally.
+ */
+public class DefaultSnykApiToken extends BaseStandardCredentials implements SnykApiToken {
+
+  @Nonnull
+  private final Secret token;
+
+  @DataBoundConstructor
+  public DefaultSnykApiToken(CredentialsScope scope, String id, String description, @Nonnull String token) {
+    super(scope, id, description);
+    this.token = fromString(token);
+  }
+
+  @Nonnull
+  @Override
+  public Secret getToken() {
+    return token;
+  }
+
+  @Extension
+  public static class DefaultSnykApiTokenDescriptor extends BaseStandardCredentialsDescriptor {
+
+    @Nonnull
+    @Override
+    public String getDisplayName() {
+      return "Snyk API token";
+    }
+  }
+}

--- a/src/main/java/io/snyk/jenkins/credentials/SnykApiToken.java
+++ b/src/main/java/io/snyk/jenkins/credentials/SnykApiToken.java
@@ -1,0 +1,30 @@
+package io.snyk.jenkins.credentials;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+
+import com.cloudbees.plugins.credentials.CredentialsNameProvider;
+import com.cloudbees.plugins.credentials.NameWith;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import hudson.Util;
+import hudson.util.Secret;
+
+/**
+ * A Snyk personal API token.
+ */
+@NameWith(value = SnykApiToken.NameProvider.class, priority = 1)
+public interface SnykApiToken extends StandardCredentials {
+
+  @Nonnull
+  Secret getToken() throws IOException, InterruptedException;
+
+  class NameProvider extends CredentialsNameProvider<SnykApiToken> {
+
+    @Nonnull
+    @Override
+    public String getName(@Nonnull SnykApiToken credentials) {
+      String description = Util.fixEmptyAndTrim(credentials.getDescription());
+      return description != null ? description : credentials.getId();
+    }
+  }
+}

--- a/src/main/resources/io/snyk/jenkins/credentials/DefaultSnykApiToken/credentials.jelly
+++ b/src/main/resources/io/snyk/jenkins/credentials/DefaultSnykApiToken/credentials.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default="true"?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+
+  <f:entry title="Token" field="token">
+    <f:password clazz="required"/>
+  </f:entry>
+  <st:include page="id-and-description" class="${descriptor.clazz}"/>
+
+</j:jelly>

--- a/src/main/resources/io/snyk/jenkins/credentials/DefaultSnykApiToken/help-token.html
+++ b/src/main/resources/io/snyk/jenkins/credentials/DefaultSnykApiToken/help-token.html
@@ -1,0 +1,4 @@
+<div>
+  To use this API, you must get your token from Snyk. It can be seen on
+  <a href="https://snyk.io/account/">https://snyk.io/account/</a> after you register with Snyk and login.
+</div>


### PR DESCRIPTION
This PR adds a new Jenkins credential type for Snyk API token.

### Motivation
* we want to move definition and validation of `SNYK_TOKEN` into build step (UI) later
* we want to filter and show only "our" types of credentials and not all
* Jenkins doesn't print out credentials in log output, so an user cannot expose `SNYK_TOKEN` env variable accidentally