### PR TITLE
chore: travis findbugs issues

### DIFF
--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,4 +1,13 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>repo.jenkins-ci.org</id>
+      <name>Jenkins CI Proxy repository</name>
+      <url>https://repo.jenkins-ci.org/public/</url>
+      <mirrorOf>*</mirrorOf>
+    </mirror>
+  </mirrors>
+
   <servers>
     <server>
       <id>maven.jenkins-ci.org</id>

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache:
   - "$HOME/.m2/wrapper"
 
 install: true
-script: ./mvnw test --show-version --batch-mode --errors --settings .mvn/settings.xml
+script: ./mvnw verify --show-version --batch-mode --errors --settings .mvn/settings.xml
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache:
   - "$HOME/.m2/wrapper"
 
 install: true
-script: ./mvnw test --show-version --batch-mode --errors
+script: ./mvnw test --show-version --batch-mode --errors --settings .mvn/settings.xml
 
 jobs:
   include:


### PR DESCRIPTION
This PR adds small changes/fixes for Travis integration:
* maven default task is `verify` instead of `test`, so if Travis builds pull requests, `findbugs:check` goal will be executed
* add jenkins ci maven repository as mirror proxy (no more annoying warning about missing POM)

