### PR TITLE
fix: do not use workspace name as project name by default

### DIFF
--- a/src/main/java/io/snyk/jenkins/SnykStepBuilder.java
+++ b/src/main/java/io/snyk/jenkins/SnykStepBuilder.java
@@ -223,8 +223,6 @@ public class SnykStepBuilder extends Builder implements SimpleBuildStep {
     }
     if (fixEmptyAndTrim(projectName) != null) {
       args.add("--project-name=" + projectName);
-    } else {
-      args.add("--project-name=" + workspace.getName());
     }
     if (fixEmptyAndTrim(additionalArguments) != null) {
       args.add(additionalArguments);


### PR DESCRIPTION
The Snyk CLI implicitly detects the project name from the manifest file and the folder of the project. This can be overridden by the `--project-name` argument. 

Removing the default behaviour where the workspace name is used as the project name to allow the implicit project name detection as the default behaviour.