### PR TITLE
fix: silent failure on snyk test

### DIFF
--- a/src/main/java/io/snyk/jenkins/SnykStepBuilder.java
+++ b/src/main/java/io/snyk/jenkins/SnykStepBuilder.java
@@ -244,6 +244,17 @@ public class SnykStepBuilder extends Builder implements SimpleBuildStep {
       boolean success = (!failOnIssues || exitCode == 0);
       build.setResult(success ? Result.SUCCESS : Result.FAILURE);
 
+      if (LOG.isTraceEnabled()) {
+        LOG.trace("Command line arguments: {}", args);
+        LOG.trace("Exit code: {}", exitCode);
+        LOG.trace("Command output: {}", snykReport.readToString());
+      }
+
+      if (!success) {
+        log.getLogger().println(snykReport.readToString());
+        return;
+      }
+
       generateSnykHtmlReport(build, workspace, launcher, log, installation.getReportExecutable(launcher, platform));
 
       if (build.getActions(SnykReportBuildAction.class).isEmpty()) {


### PR DESCRIPTION
This PR fixes suppressed output of `snyk test` command on failure and prints results to jenkins job output.

Additionally we log now on `TRACE` level:
- snyk command line arguments
- exit code
-  and output

=> this will help us with the error search later.