### PR TITLE
refactor: snyk installation remote calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,17 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
         <extensions>true</extensions>

--- a/src/main/java/io/snyk/jenkins/SnykStepBuilder.java
+++ b/src/main/java/io/snyk/jenkins/SnykStepBuilder.java
@@ -262,9 +262,10 @@ public class SnykStepBuilder extends Builder implements SimpleBuildStep {
                            .quiet(true)
                            .pwd(workspace)
                            .join();
-        success = (!failOnIssues || exitCode == 0);
-        build.setResult(success ? Result.SUCCESS : Result.FAILURE);
-        //TODO: monitor status?
+        if (exitCode != 0) {
+          log.getLogger().println("Warning: 'snyk monitor' was not successful. Exit code: " + exitCode);
+          log.getLogger().println(snykMonitorReport.readToString());
+        }
 
         if (LOG.isTraceEnabled()) {
           LOG.trace("Command line arguments: {}", argsForMonitorCommand);

--- a/src/main/java/io/snyk/jenkins/tools/internal/DownloadService.java
+++ b/src/main/java/io/snyk/jenkins/tools/internal/DownloadService.java
@@ -16,6 +16,10 @@ public class DownloadService {
   private static final String SNYK_RELEASES_TAGS = "https://api.github.com/repos/snyk/snyk/releases/tags/v%s";
   private static final String SNYK_HTML_RELEASES_LATEST = "https://api.github.com/repos/snyk/snyk-to-html/releases/latest";
 
+  private DownloadService() {
+    // squid:S1118
+  }
+
   public static URL getDownloadUrlForSnyk(@Nonnull String version, @Nonnull Platform platform) throws IOException {
     String jsonString;
     String tagName;

--- a/src/main/resources/io/snyk/jenkins/SnykStepBuilder/help-failOnIssues.html
+++ b/src/main/resources/io/snyk/jenkins/SnykStepBuilder/help-failOnIssues.html
@@ -1,6 +1,6 @@
 <div>
   <p>
-    The "When issues" selection specifies if builds should be failed or continued based on issues found by Snyk.
+    The "When issues are found" selection specifies if builds should be failed or continued based on issues found by Snyk.
   </p>
   <ul>
     <li>if "Fail the build, if severity at or above" is selected, the Jenkins build will <strong>fail</strong> if

--- a/src/test/java/io/snyk/jenkins/SnykStepBuilderTestIT.java
+++ b/src/test/java/io/snyk/jenkins/SnykStepBuilderTestIT.java
@@ -1,0 +1,27 @@
+package io.snyk.jenkins;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class SnykStepBuilderTestIT {
+
+  @Rule
+  public JenkinsRule jenkins = new JenkinsRule();
+
+  @Test
+  public void freeStyleProject_shouldFail_ifNoSnykInstallationExist() throws Exception {
+    FreeStyleProject freeStyleProject = jenkins.createFreeStyleProject("freestyle-project-without-snykInstallation");
+    SnykStepBuilder snykStepBuilder = new SnykStepBuilder();
+    snykStepBuilder.setSnykInstallation(null);
+    freeStyleProject.getBuildersList().add(snykStepBuilder);
+
+    FreeStyleBuild build = freeStyleProject.scheduleBuild2(0).get();
+
+    jenkins.assertBuildStatus(Result.FAILURE, build);
+    jenkins.assertLogContains("No snyk installation defined.", build);
+  }
+}


### PR DESCRIPTION
This PR contains following:
- correct distinguish between snyk cli and vulnerability errors (in case we have some not recoverable error e.g. missing node_modules folder, we abort jenkins job immediately without generating empty html report)
- add support for integration tests (will be executed via Travis CI on PRs)
- refactoring to reduce method complexity (sonarqube)
- small documentation fix for help snippets