### PR TITLE
Fix/rename pipeline task

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,17 +69,17 @@ To see the advanced configuration for the plugin, click the "Advanced" button. T
 
 ### Pipeline Jobs
 
-The Snyk Security Scanner pipeline integration exposes the `snyk` function to scan your dependencies as part of your pipeline script. We recommend to use "Snippet Generator" to generate needed step statement you may copy into your Jenkinsfile.
+The Snyk Security Scanner pipeline integration exposes the `snykSecurity` function to scan your dependencies as part of your pipeline script. We recommend to use "Snippet Generator" to generate needed step statement you may copy into your Jenkinsfile.
 
-The `snyk` function accepts the following parameters:
+The `snykSecurity` function accepts the following parameters:
 
+- **snykInstallation** - Snyk installation name as configured in the **Global Tool Configuration**.
+- **snykTokenId** - The ID of the API token from the Credentials plugin to be used to authenticate to Snyk.
 - **additionalArguments** (optional) - Refer to the [Snyk CLI](https://snyk.io/docs/using-snyk/) help page for information on additional arguments.
 - **failOnIssues** - This specifies if builds should be failed or continued based on issues found by Snyk.
 - **organisation** (optional) - The Snyk organisation in which this project should be tested and monitored.
 - **projectName** (optional) - A custom name for the Snyk project created for this Jenkins project on every build.
-- **severity** - Only report vulnerabilities of provided level or higher (low/medium/high).
-- **snykInstallation** - Snyk installation configured in the **Global Tool Configuration**.
-- **snykTokenId** - The ID for the API token from the Credentials plugin to be used to authenticate to Snyk.
+- **severity** (optional) - Only report vulnerabilities of provided level or higher (low/medium/high). Default is low.
 - **targetFile** (optional) - The path to the manifest file to be used by Snyk.
 
 

--- a/src/main/java/io/snyk/jenkins/SnykStepBuilder.java
+++ b/src/main/java/io/snyk/jenkins/SnykStepBuilder.java
@@ -358,7 +358,7 @@ public class SnykStepBuilder extends Builder implements SimpleBuildStep {
   }
 
   @Extension
-  @Symbol("snyk")
+  @Symbol("snykSecurity")
   public static class SnykStepBuilderDescriptor extends BuildStepDescriptor<Builder> {
 
     @CopyOnWrite


### PR DESCRIPTION
Make sure the pipeline task is called `snykSecurity`, just like in v1.