### PR TITLE
FIX: additional params are now broken up

### DIFF
--- a/src/main/java/io/snyk/jenkins/SnykStepBuilder.java
+++ b/src/main/java/io/snyk/jenkins/SnykStepBuilder.java
@@ -323,7 +323,12 @@ public class SnykStepBuilder extends Builder implements SimpleBuildStep {
       args.add("--project-name=" + projectName);
     }
     if (fixEmptyAndTrim(additionalArguments) != null) {
-      args.add(additionalArguments);
+      for (String addArg : additionalArguments.split(" ")) 
+      { 
+        if (fixEmptyAndTrim(addArg) != null) {
+          args.add(addArg);
+        }
+      }
     }
 
     return args;


### PR DESCRIPTION
before the change `additionalArguments` were fed to command as a one string. This fixes it by breaking up the string with ` ` and feeding each as a separate argument