### PR TITLE
fix: custom build tool path

### DIFF
--- a/src/main/java/io/snyk/jenkins/CustomBuildToolPathCallable.java
+++ b/src/main/java/io/snyk/jenkins/CustomBuildToolPathCallable.java
@@ -1,0 +1,51 @@
+package io.snyk.jenkins;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import hudson.FilePath;
+import hudson.remoting.VirtualChannel;
+import org.jenkinsci.remoting.RoleChecker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.lang.String.join;
+import static org.apache.commons.lang.StringUtils.chomp;
+
+class CustomBuildToolPathCallable implements FilePath.FileCallable<String> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CustomBuildToolPathCallable.class.getName());
+  private static final long serialVersionUID = 1L;
+
+  @Override
+  public String invoke(File snykToolDirectory, VirtualChannel channel) {
+    String oldPath = System.getenv("PATH");
+    String home = snykToolDirectory.getAbsolutePath();
+    String toolsDirectory = home.substring(0, home.indexOf("tools") - 1) + File.separator + "tools";
+
+    try (Stream<Path> toolsSubDirectories = Files.walk(Paths.get(toolsDirectory))) {
+      List<String> toolsPaths = new ArrayList<>();
+      toolsSubDirectories.filter(Files::isDirectory)
+                         .filter(path -> !path.toString().contains("SnykInstallation"))
+                         .filter(path -> !path.toString().contains("jansi-native"))
+                         .forEach(entry -> toolsPaths.add(chomp(entry.toAbsolutePath().toString())));
+
+      String customBuildToolPath = join(File.pathSeparator, toolsPaths);
+      return oldPath + File.pathSeparator + customBuildToolPath;
+    } catch (IOException ex) {
+      LOG.error("Could not iterate sub-directories in tools directory", ex);
+      return oldPath;
+    }
+  }
+
+  @Override
+  public void checkRoles(RoleChecker roleChecker) {
+    //squid:S1186
+  }
+}

--- a/src/main/java/io/snyk/jenkins/SnykStepBuilder.java
+++ b/src/main/java/io/snyk/jenkins/SnykStepBuilder.java
@@ -57,7 +57,6 @@ import static hudson.Util.fixEmptyAndTrim;
 import static hudson.Util.fixNull;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
 public class SnykStepBuilder extends Builder implements SimpleBuildStep {
@@ -218,11 +217,14 @@ public class SnykStepBuilder extends Builder implements SimpleBuildStep {
     //workaround until we implement Step interface
     VirtualChannel nodeChannel = node.getChannel();
     if (nodeChannel != null) {
-      FilePath snykToolHome = new FilePath(nodeChannel, requireNonNull(installation.getHome()));
-      String customBuildPath = snykToolHome.act(new CustomBuildToolPathCallable());
-      env.put("PATH", customBuildPath);
+      String toolHome = installation.getHome();
+      if (fixEmptyAndTrim(toolHome) != null) {
+        FilePath snykToolHome = new FilePath(nodeChannel, toolHome);
+        String customBuildPath = snykToolHome.act(new CustomBuildToolPathCallable());
+        env.put("PATH", customBuildPath);
 
-      LOG.info("Custom build tool path: '{}'", customBuildPath);
+        LOG.info("Custom build tool path: '{}'", customBuildPath);
+      }
     }
 
     FilePath snykTestReport = workspace.child(SNYK_TEST_REPORT_JSON);

--- a/src/main/java/io/snyk/jenkins/SnykStepBuilder.java
+++ b/src/main/java/io/snyk/jenkins/SnykStepBuilder.java
@@ -323,8 +323,7 @@ public class SnykStepBuilder extends Builder implements SimpleBuildStep {
       args.add("--project-name=" + projectName);
     }
     if (fixEmptyAndTrim(additionalArguments) != null) {
-      for (String addArg : additionalArguments.split(" ")) 
-      { 
+      for (String addArg : additionalArguments.split(" ")) {
         if (fixEmptyAndTrim(addArg) != null) {
           args.add(addArg);
         }

--- a/src/main/java/io/snyk/jenkins/tools/SnykInstallation.java
+++ b/src/main/java/io/snyk/jenkins/tools/SnykInstallation.java
@@ -126,19 +126,13 @@ public class SnykInstallation extends ToolInstallation implements EnvironmentSpe
 
     @Override
     public SnykInstallation[] getInstallations() {
-      Jenkins instance = Jenkins.getInstanceOrNull();
-      if (instance == null) {
-        throw new IllegalStateException("Jenkins has not been started, or was already shut down");
-      }
+      Jenkins instance = Jenkins.getInstance();
       return instance.getDescriptorByType(SnykStepBuilderDescriptor.class).getInstallations();
     }
 
     @Override
     public void setInstallations(SnykInstallation... installations) {
-      Jenkins instance = Jenkins.getInstanceOrNull();
-      if (instance == null) {
-        throw new IllegalStateException("Jenkins has not been started, or was already shut down");
-      }
+      Jenkins instance = Jenkins.getInstance();
       instance.getDescriptorByType(SnykStepBuilderDescriptor.class).setInstallations(installations);
     }
   }


### PR DESCRIPTION
This PR fixes an issue with missing build tools during freestyle and pipeline jobs.

E.g. if build tool is not set on the agent and will be installed via auto-installer, snyk CLI cannot find this tool in `PATH`, so we have a following error, e.g:
```
Error result: /bin/sh: 1: mvn: not found

Please make sure that Apache Maven Dependency Plugin version 2.2 or above is installed, and that `mvn dependency:tree -DoutputType=dot --file="pom.xml"` executes successfully on this project.

If the problem persists, collect the output of `mvn dependency:tree -DoutputType=dot --file="pom.xml"` and contact support@snyk.io
```

@adrukh, please note, this is a workaround. We should implement `Step` interface later and grep EnvVars from pipeline step context.