### PR TITLE
fix: check if tools directory is not available on agents

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,12 @@
       <artifactId>jodd-lagarto</artifactId>
       <version>5.0.11</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/io/snyk/jenkins/CustomBuildToolPathCallable.java
+++ b/src/main/java/io/snyk/jenkins/CustomBuildToolPathCallable.java
@@ -20,14 +20,19 @@ import static org.apache.commons.lang.StringUtils.chomp;
 
 class CustomBuildToolPathCallable implements FilePath.FileCallable<String> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(CustomBuildToolPathCallable.class.getName());
   private static final long serialVersionUID = 1L;
+  private static final Logger LOG = LoggerFactory.getLogger(CustomBuildToolPathCallable.class.getName());
+  private static final String TOOLS_DIRECTORY = "tools";
 
   @Override
   public String invoke(File snykToolDirectory, VirtualChannel channel) {
     String oldPath = System.getenv("PATH");
     String home = snykToolDirectory.getAbsolutePath();
-    String toolsDirectory = home.substring(0, home.indexOf("tools") - 1) + File.separator + "tools";
+    if (!home.contains(TOOLS_DIRECTORY)) {
+      LOG.info("env.PATH will be not modified, because there are no configured global tools");
+      return oldPath;
+    }
+    String toolsDirectory = home.substring(0, home.indexOf(TOOLS_DIRECTORY) - 1) + File.separator + TOOLS_DIRECTORY;
 
     try (Stream<Path> toolsSubDirectories = Files.walk(Paths.get(toolsDirectory))) {
       List<String> toolsPaths = new ArrayList<>();

--- a/src/main/java/io/snyk/jenkins/CustomBuildToolPathCallable.java
+++ b/src/main/java/io/snyk/jenkins/CustomBuildToolPathCallable.java
@@ -28,10 +28,10 @@ class CustomBuildToolPathCallable implements FilePath.FileCallable<String> {
   public String invoke(File snykToolDirectory, VirtualChannel channel) {
     String oldPath = System.getenv("PATH");
     String home = snykToolDirectory.getAbsolutePath();
-    if (!home.contains(TOOLS_DIRECTORY)) {
-      LOG.info("env.PATH will be not modified, because there are no configured global tools");
-      return oldPath;
-    }
+    // if (!home.contains(TOOLS_DIRECTORY)) {
+    //   LOG.info("env.PATH will be not modified, because there are no configured global tools");
+    //   return oldPath;
+    // }
     String toolsDirectory = home.substring(0, home.indexOf(TOOLS_DIRECTORY) - 1) + File.separator + TOOLS_DIRECTORY;
 
     try (Stream<Path> toolsSubDirectories = Files.walk(Paths.get(toolsDirectory))) {

--- a/src/main/java/io/snyk/jenkins/CustomBuildToolPathCallable.java
+++ b/src/main/java/io/snyk/jenkins/CustomBuildToolPathCallable.java
@@ -28,10 +28,10 @@ class CustomBuildToolPathCallable implements FilePath.FileCallable<String> {
   public String invoke(File snykToolDirectory, VirtualChannel channel) {
     String oldPath = System.getenv("PATH");
     String home = snykToolDirectory.getAbsolutePath();
-    // if (!home.contains(TOOLS_DIRECTORY)) {
-    //   LOG.info("env.PATH will be not modified, because there are no configured global tools");
-    //   return oldPath;
-    // }
+    if (!home.contains(TOOLS_DIRECTORY)) {
+      LOG.info("env.PATH will be not modified, because there are no configured global tools");
+      return oldPath;
+    }
     String toolsDirectory = home.substring(0, home.indexOf(TOOLS_DIRECTORY) - 1) + File.separator + TOOLS_DIRECTORY;
 
     try (Stream<Path> toolsSubDirectories = Files.walk(Paths.get(toolsDirectory))) {

--- a/src/test/java/io/snyk/jenkins/CustomBuildToolPathCallableTest.java
+++ b/src/test/java/io/snyk/jenkins/CustomBuildToolPathCallableTest.java
@@ -1,0 +1,38 @@
+package io.snyk.jenkins;
+
+import java.io.File;
+
+import hudson.remoting.VirtualChannel;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.mockito.Mockito.when;
+
+public class CustomBuildToolPathCallableTest {
+
+  @Rule
+  public MockitoRule mockitoRule = MockitoJUnit.rule();
+  @Mock
+  private File snykToolDirectory;
+  @Mock
+  private VirtualChannel channel;
+
+  @Test
+  public void invoke_shouldNotThrownAnyExceptions_ifToolDirectoryNotContainsToolsWord() {
+    when(snykToolDirectory.getAbsolutePath()).thenReturn("/path-without-t.o.o.l.s-word");
+    CustomBuildToolPathCallable customBuildToolPath = new CustomBuildToolPathCallable();
+
+    customBuildToolPath.invoke(snykToolDirectory, channel);
+  }
+
+  @Test
+  public void invoke_shouldNotThrownAnyExceptions_ifToolDirectoryContainsToolsWord() {
+    when(snykToolDirectory.getAbsolutePath()).thenReturn("/opt/jenkins/tools/io.snyk.tools.SnykInstallation");
+    CustomBuildToolPathCallable customBuildToolPath = new CustomBuildToolPathCallable();
+
+    customBuildToolPath.invoke(snykToolDirectory, channel);
+  }
+}


### PR DESCRIPTION
This PR fixes an issue if Snyk installation directory is overridden and no Jenkins global tools are configured.

Stacktrace for the issue:
```
ERROR: Build step failed with exception
Also:   hudson.remoting.Channel$CallSiteStackTrace: Remote call to jenkins-agent-dev-1
		at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1743)
		at hudson.remoting.UserRequest$ExceptionResponse.retrieve(UserRequest.java:357)
		at hudson.remoting.Channel.call(Channel.java:957)
		at hudson.FilePath.act(FilePath.java:1069)
		at hudson.FilePath.act(FilePath.java:1058)
		at io.snyk.jenkins.SnykStepBuilder.perform(SnykStepBuilder.java:223)
		at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:81)
		at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
		at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:744)
		at hudson.model.Build$BuildExecution.build(Build.java:206)
		at hudson.model.Build$BuildExecution.doRun(Build.java:163)
		at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:504)
		at hudson.model.Run.execute(Run.java:1816)
		at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
		at hudson.model.ResourceController.execute(ResourceController.java:97)
		at hudson.model.Executor.run(Executor.java:429)
java.lang.StringIndexOutOfBoundsException: String index out of range: -2
	at java.lang.String.substring(String.java:1967)
	at io.snyk.jenkins.CustomBuildToolPathCallable.invoke(CustomBuildToolPathCallable.java:30)
	at io.snyk.jenkins.CustomBuildToolPathCallable.invoke(CustomBuildToolPathCallable.java:21)
	at hudson.FilePath$FileCallableWrapper.call(FilePath.java:3042)
	at hudson.remoting.UserRequest.perform(UserRequest.java:212)
	at hudson.remoting.UserRequest.perform(UserRequest.java:54)
	at hudson.remoting.Request$2.run(Request.java:369)
	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:72)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Build step 'Invoke Snyk Security task' marked build as failure
```