### PR TITLE
chore: define build configurations for jenkins CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,6 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(configurations: [
+  [ platform: "linux", jdk: "8" ],
+  [ platform: "windows", jdk: "8" ],
+  [ platform: "linux", jdk: "8", jenkins: "2.60.3", javaLabel: 8 ],
+  [ platform: "windows", jdk: "8", jenkins: "2.60.3", javaLabel: 8 ]
+])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,9 @@
 #!/usr/bin/env groovy
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-//buildPlugin(jenkinsVersions: [null, '2.60.3'])
-buildPlugin()
+buildPlugin(configurations: [
+  [ platform: "linux", jdk: "8" ],
+  [ platform: "windows", jdk: "8" ],
+  [ platform: "linux", jdk: "8", jenkins: "2.60.3", javaLabel: 8 ],
+  [ platform: "windows", jdk: "8", jenkins: "2.60.3", javaLabel: 8 ]
+])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,4 @@
-buildPlugin(configurations: [
-  [ platform: "linux", jdk: "8" ],
-  [ platform: "windows", jdk: "8" ],
-  [ platform: "linux", jdk: "8", jenkins: "2.60.3", javaLabel: 8 ],
-  [ platform: "windows", jdk: "8", jenkins: "2.60.3", javaLabel: 8 ]
-])
+#!/usr/bin/env groovy
+
+/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
+buildPlugin(jenkinsVersions: [null, '2.60.3'])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,5 @@
 #!/usr/bin/env groovy
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin(jenkinsVersions: [null, '2.60.3'])
+//buildPlugin(jenkinsVersions: [null, '2.60.3'])
+buildPlugin()

--- a/src/main/java/io/snyk/jenkins/CustomBuildToolPathCallable.java
+++ b/src/main/java/io/snyk/jenkins/CustomBuildToolPathCallable.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.FilePath;
 import hudson.remoting.VirtualChannel;
 import org.jenkinsci.remoting.RoleChecker;
@@ -23,6 +24,7 @@ class CustomBuildToolPathCallable implements FilePath.FileCallable<String> {
   private static final Logger LOG = LoggerFactory.getLogger(CustomBuildToolPathCallable.class.getName());
   private static final long serialVersionUID = 1L;
 
+  @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", justification = "spotbugs issue (java 11)")
   @Override
   public String invoke(File snykToolDirectory, VirtualChannel channel) {
     String oldPath = System.getenv("PATH");


### PR DESCRIPTION
This PR fixes failed jobs on Jenkins CI.

We don't want to use `buildPlugin.recommendedConfigurations()` because it may (will) change over time and our CI will break if the new recommended configuration is not compatible.

Following configurations are defined:
- linux, jdk8, latest jenkins version
- linux, jdk8, minimal supported jenkins version from our plugin (2.60.3)
- windows, jdk8, latest jenkins version
- windows, jdk8, minimal supported jenkins version from our plugin (2.60.3)