### PR TITLE
fix: add unit test to test split of additional arguments

### DIFF
--- a/src/main/java/io/snyk/jenkins/SnykStepBuilder.java
+++ b/src/main/java/io/snyk/jenkins/SnykStepBuilder.java
@@ -56,6 +56,7 @@ import static com.cloudbees.plugins.credentials.CredentialsProvider.lookupCreden
 import static hudson.Util.fixEmptyAndTrim;
 import static hudson.Util.fixNull;
 import static hudson.Util.replaceMacro;
+import static hudson.Util.tokenize;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.joining;
@@ -337,7 +338,7 @@ public class SnykStepBuilder extends Builder implements SimpleBuildStep {
       args.add("--project-name=" + replaceMacro(projectName, env));
     }
     if (fixEmptyAndTrim(additionalArguments) != null) {
-      for (String addArg : additionalArguments.split(" ")) {
+      for (String addArg : tokenize(additionalArguments)) {
         if (fixEmptyAndTrim(addArg) != null) {
           args.add(replaceMacro(addArg, env));
         }

--- a/src/test/java/io/snyk/jenkins/SnykStepBuilderTest.java
+++ b/src/test/java/io/snyk/jenkins/SnykStepBuilderTest.java
@@ -56,4 +56,21 @@ public class SnykStepBuilderTest {
                                                     "--docker",
                                                     "image:development-15"));
   }
+
+  @Test
+  public void buildArgumentList_shouldSplitAdditionalArgumentsWithAnyWhitespaceCharacter() {
+    EnvVars env = new EnvVars();
+    SnykStepBuilder snykStepBuilder = new SnykStepBuilder();
+    snykStepBuilder.setAdditionalArguments("--dev\n \n-d");
+
+    ArgumentListBuilder resolvedArguments = snykStepBuilder.buildArgumentList("/usr/bin/snyk", "test", env);
+
+    assertThat(resolvedArguments.toList(), hasSize(6));
+    assertThat(resolvedArguments.toList(), contains("/usr/bin/snyk",
+                                                    "test",
+                                                    "--json",
+                                                    "--severity-threshold=low",
+                                                    "--dev",
+                                                    "-d"));
+  }
 }


### PR DESCRIPTION
This PR fixes splitting of additional arguments.

first commit should fail to show incorrect behavior.