### PR TITLE
fix: filter custom tool sub-directories correctly

### DIFF
--- a/src/main/java/io/snyk/jenkins/CustomBuildToolPathCallable.java
+++ b/src/main/java/io/snyk/jenkins/CustomBuildToolPathCallable.java
@@ -40,7 +40,7 @@ class CustomBuildToolPathCallable implements FilePath.FileCallable<String> {
       List<String> toolsPaths = new ArrayList<>();
       toolsSubDirectories.filter(Files::isDirectory)
                          .filter(path -> !path.toString().contains("SnykInstallation"))
-                         .filter(path -> !path.toString().contains("jansi-native"))
+                         .filter(path -> path.toString().endsWith("bin"))
                          .forEach(entry -> toolsPaths.add(chomp(entry.toAbsolutePath().toString())));
 
       String customBuildToolPath = join(File.pathSeparator, toolsPaths);


### PR DESCRIPTION
This PR fixes "Argument list too long" issue:
- `env.PATH` can be maximal 8192 character long, some installers have too many folders so we add to custom build path only paths that ends with `bin` as folder name
- all smoke tests on my internal system run correctly

Link to the issue [on jenkins.io](https://wiki.jenkins.io/display/JENKINS/Snyk+Security+Plugin?focusedCommentId=173703622#comment-173703622).