### PR TITLE
fix: throw FlowInterruptedException to stop snyk pipeline step correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: java
+dist: trusty
 
 jdk:
 - oraclejdk8

--- a/src/main/java/io/snyk/jenkins/workflow/FoundIssuesCause.java
+++ b/src/main/java/io/snyk/jenkins/workflow/FoundIssuesCause.java
@@ -5,6 +5,6 @@ import jenkins.model.CauseOfInterruption;
 public final class FoundIssuesCause extends CauseOfInterruption {
   @Override
   public String getShortDescription() {
-    return "Snyk detected vulnerability issues.";
+    return "Snyk has detected security vulnerabilities in your project.";
   }
 }

--- a/src/main/java/io/snyk/jenkins/workflow/FoundIssuesCause.java
+++ b/src/main/java/io/snyk/jenkins/workflow/FoundIssuesCause.java
@@ -1,0 +1,10 @@
+package io.snyk.jenkins.workflow;
+
+import jenkins.model.CauseOfInterruption;
+
+public final class FoundIssuesCause extends CauseOfInterruption {
+  @Override
+  public String getShortDescription() {
+    return "Snyk detected vulnerability issues.";
+  }
+}

--- a/src/main/java/io/snyk/jenkins/workflow/SnykSecurityStep.java
+++ b/src/main/java/io/snyk/jenkins/workflow/SnykSecurityStep.java
@@ -34,6 +34,7 @@ import io.snyk.jenkins.transform.ReportConverter;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
@@ -353,6 +354,11 @@ public class SnykSecurityStep extends Step {
         build.setResult(Result.FAILURE);
         return null;
       }
+
+      if (snykSecurityStep.failOnIssues && Result.FAILURE.equals(build.getResult())) {
+        throw new FlowInterruptedException(Result.FAILURE, new FoundIssuesCause());
+      }
+
       return null;
     }
 


### PR DESCRIPTION
This PR fixes an issue that pipelines are not stopped if snyk step find vuln issues and `failOnIssues` is true.

We throw now `FlowInterruptedException` to control pipeline flow behavior. As a "nice" bonus we show  the message `Snyk detected vulnerability issues.` in job overview if the pipeline was stopped because of snyk step.