### PR TITLE
fix: missing multistage reports

### DIFF
--- a/src/main/java/io/snyk/jenkins/SnykStepBuilder.java
+++ b/src/main/java/io/snyk/jenkins/SnykStepBuilder.java
@@ -304,9 +304,9 @@ public class SnykStepBuilder extends Builder {
 
       if (build.getActions(SnykReportBuildAction.class).isEmpty()) {
         build.addAction(new SnykReportBuildAction(build));
-        ArtifactArchiver artifactArchiver = new ArtifactArchiver(workspace.getName() + "_" + SNYK_REPORT_HTML);
-        artifactArchiver.perform(build, workspace, launcher, log);
       }
+      ArtifactArchiver artifactArchiver = new ArtifactArchiver(workspace.getName() + "_" + SNYK_REPORT_HTML);
+      artifactArchiver.perform(build, workspace, launcher, log);
       return result;
     } catch (IOException ex) {
       Util.displayIOException(ex, log);

--- a/src/main/java/io/snyk/jenkins/SnykStepBuilder.java
+++ b/src/main/java/io/snyk/jenkins/SnykStepBuilder.java
@@ -297,6 +297,7 @@ public class SnykStepBuilder extends Builder {
         JSONObject snykMonitorReportJson = JSONObject.fromObject(snykMonitorReport.readToString());
         if (snykMonitorReportJson.has("uri")) {
           monitorUri = snykMonitorReportJson.getString("uri");
+          log.getLogger().println("Explore the snapshot at " + monitorUri);
         }
       }
 

--- a/src/main/java/io/snyk/jenkins/workflow/SnykSecurityStep.java
+++ b/src/main/java/io/snyk/jenkins/workflow/SnykSecurityStep.java
@@ -407,9 +407,9 @@ public class SnykSecurityStep extends Step {
 
         if (build.getActions(SnykReportBuildAction.class).isEmpty()) {
           build.addAction(new SnykReportBuildAction(build));
-          ArtifactArchiver artifactArchiver = new ArtifactArchiver(workspace.getName() + "_" + SNYK_REPORT_HTML);
-          artifactArchiver.perform(build, workspace, launcher, log);
         }
+        ArtifactArchiver artifactArchiver = new ArtifactArchiver(workspace.getName() + "_" + SNYK_REPORT_HTML);
+        artifactArchiver.perform(build, workspace, launcher, log);
       } catch (IOException ex) {
         Util.displayIOException(ex, log);
         ex.printStackTrace(log.fatalError("Snyk command execution failed"));

--- a/src/main/java/io/snyk/jenkins/workflow/SnykSecurityStep.java
+++ b/src/main/java/io/snyk/jenkins/workflow/SnykSecurityStep.java
@@ -400,6 +400,7 @@ public class SnykSecurityStep extends Step {
           JSONObject snykMonitorReportJson = JSONObject.fromObject(snykMonitorReport.readToString());
           if (snykMonitorReportJson.has("uri")) {
             monitorUri = snykMonitorReportJson.getString("uri");
+            log.getLogger().println("Explore the snapshot at " + monitorUri);
           }
         }
 


### PR DESCRIPTION
This PR fixes an issue when not all generated html reports are transferred from agents to master node. Now we print in a job console output the snapshot URL for `monitor` command.