### PR TITLE
chore: upgrade maven wrapper to version 3.6.3

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.0/apache-maven-3.6.0-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip


### PR DESCRIPTION
This PR updates maven wrapper version to 3.6.3.
P.S.: Th previous version has some issues with dependency resolution in IntelliJ.