### PR TITLE
feat: parse json using steaming API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.10.2</version>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>symbol-annotation</artifactId>
       <version>1.17</version>

--- a/src/main/java/io/snyk/jenkins/SnykStepBuilder.java
+++ b/src/main/java/io/snyk/jenkins/SnykStepBuilder.java
@@ -38,10 +38,12 @@ import hudson.util.ArgumentListBuilder;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import io.snyk.jenkins.credentials.SnykApiToken;
+import io.snyk.jenkins.model.ObjectMapperHelper;
+import io.snyk.jenkins.model.SnykMonitorResult;
+import io.snyk.jenkins.model.SnykTestResult;
 import io.snyk.jenkins.tools.SnykInstallation;
 import io.snyk.jenkins.transform.ReportConverter;
 import jenkins.model.Jenkins;
-import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -249,23 +251,28 @@ public class SnykStepBuilder extends Builder {
       boolean result = (!failOnIssues || exitCode == 0);
       build.setResult(result ? Result.SUCCESS : Result.FAILURE);
 
+      String snykTestReportAsString = snykTestReport.readToString();
       if (LOG.isTraceEnabled()) {
         LOG.trace("Job: '{}'", build);
         LOG.trace("Command line arguments: {}", argsForTestCommand);
         LOG.trace("Exit code: {}", exitCode);
-        LOG.trace("Command output: {}", snykTestReport.readToString());
+        LOG.trace("Command output: {}", snykTestReportAsString);
       }
 
-      JSONObject snykTestReportJson = JSONObject.fromObject(snykTestReport.readToString());
-      // exit on cli error immediately
-      if (snykTestReportJson.has("error")) {
-        log.getLogger().println("Error result: " + snykTestReportJson.getString("error"));
+      SnykTestResult snykTestResult = ObjectMapperHelper.unmarshallTestResult(snykTestReportAsString);
+      if (snykTestResult == null) {
+        log.getLogger().println("Could not parse generated json report file.");
         build.setResult(Result.FAILURE);
         return false;
       }
-
-      if (snykTestReportJson.has("summary") && snykTestReportJson.has("uniqueCount")) {
-        log.getLogger().println(format("Result: %s known issues | %s", snykTestReportJson.getString("uniqueCount"), snykTestReportJson.getString("summary")));
+      // exit on cli error immediately
+      if (fixEmptyAndTrim(snykTestResult.error) != null) {
+        log.getLogger().println("Error result: " + snykTestResult.error);
+        build.setResult(Result.FAILURE);
+        return false;
+      }
+      if (!snykTestResult.ok) {
+        log.getLogger().println(format("Result: %s known vulnerabilities | %s dependencies", snykTestResult.uniqueCount, snykTestResult.dependencyCount));
       }
 
       String monitorUri = "";
@@ -283,21 +290,21 @@ public class SnykStepBuilder extends Builder {
                            .quiet(true)
                            .pwd(workspace)
                            .join();
+        String snykMonitorReportAsString = snykMonitorReport.readToString();
         if (exitCode != 0) {
           log.getLogger().println("Warning: 'snyk monitor' was not successful. Exit code: " + exitCode);
-          log.getLogger().println(snykMonitorReport.readToString());
+          log.getLogger().println(snykMonitorReportAsString);
         }
 
         if (LOG.isTraceEnabled()) {
           LOG.trace("Command line arguments: {}", argsForMonitorCommand);
           LOG.trace("Exit code: {}", exitCode);
-          LOG.trace("Command output: {}", snykMonitorReport.readToString());
+          LOG.trace("Command output: {}", snykMonitorReportAsString);
         }
 
-        JSONObject snykMonitorReportJson = JSONObject.fromObject(snykMonitorReport.readToString());
-        if (snykMonitorReportJson.has("uri")) {
-          monitorUri = snykMonitorReportJson.getString("uri");
-          log.getLogger().println("Explore the snapshot at " + monitorUri);
+        SnykMonitorResult snykMonitorResult = ObjectMapperHelper.unmarshallMonitorResult(snykMonitorReportAsString);
+        if (snykMonitorResult != null && fixEmptyAndTrim(snykMonitorResult.uri) != null) {
+          log.getLogger().println("Explore the snapshot at " + snykMonitorResult.uri);
         }
       }
 

--- a/src/main/java/io/snyk/jenkins/model/ObjectMapperHelper.java
+++ b/src/main/java/io/snyk/jenkins/model/ObjectMapperHelper.java
@@ -1,0 +1,109 @@
+package io.snyk.jenkins.model;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.MappingJsonFactory;
+
+public class ObjectMapperHelper {
+
+  private static final JsonFactory JSON_FACTORY;
+
+  static {
+    JSON_FACTORY = new MappingJsonFactory();
+  }
+
+  private ObjectMapperHelper() {
+  }
+
+  public static SnykMonitorResult unmarshallMonitorResult(String content) throws IOException {
+    if (content == null || content.isEmpty()) {
+      return null;
+    }
+
+    try (JsonParser parser = JSON_FACTORY.createParser(content)) {
+      if (parser.nextToken() != JsonToken.START_OBJECT) {
+        return null;
+      }
+
+      SnykMonitorResult snykMonitorResult = new SnykMonitorResult();
+      while (parser.nextToken() != JsonToken.END_OBJECT) {
+        String fieldName = parser.getCurrentName();
+
+        if ("uri".equals(fieldName)) {
+          parser.nextToken();
+          snykMonitorResult.uri = parser.getText();
+        } else {
+          parser.skipChildren();
+        }
+      }
+      return snykMonitorResult;
+    }
+  }
+
+  public static SnykTestResult unmarshallTestResult(String content) throws IOException {
+    if (content == null || content.isEmpty()) {
+      return null;
+    }
+
+    try (JsonParser parser = JSON_FACTORY.createParser(content)) {
+      JsonToken token = parser.nextToken();
+      if (token == JsonToken.START_ARRAY) {
+        List<SnykTestResult> testStatuses = new ArrayList<>();
+        while (parser.nextToken() != JsonToken.END_ARRAY) {
+          testStatuses.add(readTestResult(parser));
+        }
+        return aggregateTestResults(testStatuses);
+      } else if (token == JsonToken.START_OBJECT) {
+        return readTestResult(parser);
+      } else {
+        return null;
+      }
+    }
+  }
+
+  private static SnykTestResult readTestResult(JsonParser parser) throws IOException {
+    SnykTestResult snykTestResult = new SnykTestResult();
+
+    while (parser.nextToken() != JsonToken.END_OBJECT) {
+      String fieldName = parser.getCurrentName();
+
+      if ("ok".equals(fieldName)) {
+        parser.nextToken();
+        snykTestResult.ok = parser.getBooleanValue();
+      } else if ("error".equals(fieldName)) {
+        parser.nextToken();
+        snykTestResult.error = parser.getText();
+      } else if ("uniqueCount".equals(fieldName)) {
+        parser.nextToken();
+        snykTestResult.uniqueCount = parser.getIntValue();
+      } else if ("dependencyCount".equals(fieldName)) {
+        parser.nextToken();
+        snykTestResult.dependencyCount = parser.getIntValue();
+      } else {
+        parser.skipChildren();
+      }
+    }
+
+    return snykTestResult;
+  }
+
+  private static SnykTestResult aggregateTestResults(List<SnykTestResult> testResults) {
+    SnykTestResult aggregatedTestResult = new SnykTestResult();
+
+    testResults.forEach(entity -> {
+      aggregatedTestResult.ok = aggregatedTestResult.ok && entity.ok;
+      aggregatedTestResult.error = (entity.error != null && !entity.error.isEmpty())
+        ? String.join(". ", aggregatedTestResult.error, entity.error)
+        : aggregatedTestResult.error;
+      aggregatedTestResult.dependencyCount += entity.dependencyCount;
+      aggregatedTestResult.uniqueCount += entity.uniqueCount;
+    });
+
+    return aggregatedTestResult;
+  }
+}

--- a/src/main/java/io/snyk/jenkins/model/SnykMonitorResult.java
+++ b/src/main/java/io/snyk/jenkins/model/SnykMonitorResult.java
@@ -1,0 +1,5 @@
+package io.snyk.jenkins.model;
+
+public class SnykMonitorResult {
+  public String uri;
+}

--- a/src/main/java/io/snyk/jenkins/model/SnykTestResult.java
+++ b/src/main/java/io/snyk/jenkins/model/SnykTestResult.java
@@ -1,0 +1,8 @@
+package io.snyk.jenkins.model;
+
+public class SnykTestResult {
+  public boolean ok = true;
+  public String error;
+  public int dependencyCount;
+  public int uniqueCount;
+}

--- a/src/test/java/io/snyk/jenkins/model/ObjectMapperHelperTest.java
+++ b/src/test/java/io/snyk/jenkins/model/ObjectMapperHelperTest.java
@@ -1,0 +1,95 @@
+package io.snyk.jenkins.model;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static java.util.Objects.requireNonNull;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class ObjectMapperHelperTest {
+
+  private static File TEST_FIXTURES_DIRECTORY;
+
+  @BeforeClass
+  public static void setupAll() throws Exception {
+    URL testDirectoryUrl = ObjectMapperHelper.class.getClassLoader().getResource("./fixtures");
+    TEST_FIXTURES_DIRECTORY = new File(requireNonNull(testDirectoryUrl).toURI());
+  }
+
+  @Test
+  public void unmarshallMonitorResult_withURI() throws IOException {
+    Path monitorReportPath = Paths.get(TEST_FIXTURES_DIRECTORY.getAbsolutePath(), "monitor", "snyk_monitor_with_uri.json");
+    String monitorReport = new String(Files.readAllBytes(monitorReportPath));
+
+    SnykMonitorResult snykMonitorResult = ObjectMapperHelper.unmarshallMonitorResult(monitorReport);
+
+    assertThat(snykMonitorResult.uri, equalTo("http://localhost:8000/org/dummy-user/project/long-uuid-here/history/long-uuid-here-again"));
+  }
+
+  @Test
+  public void unmarshallMonitorResult_withoutURI() throws IOException {
+    Path monitorReportPath = Paths.get(TEST_FIXTURES_DIRECTORY.getAbsolutePath(), "monitor", "snyk_monitor_without_uri.json");
+    String monitorReport = new String(Files.readAllBytes(monitorReportPath));
+
+    SnykMonitorResult snykMonitorResult = ObjectMapperHelper.unmarshallMonitorResult(monitorReport);
+
+    assertThat(snykMonitorResult.uri, nullValue());
+  }
+
+  @Test
+  public void unmarshallTestResult_singleModule_withVulns() throws IOException {
+    Path testReportPath = Paths.get(TEST_FIXTURES_DIRECTORY.getAbsolutePath(), "test", "single-module-project", "snyk_report_with_vulns.json");
+    String testReport = new String(Files.readAllBytes(testReportPath));
+
+    SnykTestResult snykTestResult = ObjectMapperHelper.unmarshallTestResult(testReport);
+
+    assertThat(snykTestResult.ok, equalTo(false));
+    assertThat(snykTestResult.dependencyCount, equalTo(10));
+    assertThat(snykTestResult.uniqueCount, equalTo(3));
+  }
+
+  @Test
+  public void unmarshallTestResult_singleModule_withoutVulns() throws IOException {
+    Path testReportPath = Paths.get(TEST_FIXTURES_DIRECTORY.getAbsolutePath(), "test", "single-module-project", "snyk_report_without_vulns.json");
+    String testReport = new String(Files.readAllBytes(testReportPath));
+
+    SnykTestResult snykTestResult = ObjectMapperHelper.unmarshallTestResult(testReport);
+
+    assertThat(snykTestResult.ok, equalTo(true));
+    assertThat(snykTestResult.dependencyCount, equalTo(33));
+    assertThat(snykTestResult.uniqueCount, equalTo(0));
+  }
+
+  @Test
+  public void unmarshallTestResult_multiModule_withVulns() throws IOException {
+    Path testReportPath = Paths.get(TEST_FIXTURES_DIRECTORY.getAbsolutePath(), "test", "multi-module-project", "snyk_report_with_vulns.json");
+    String testReport = new String(Files.readAllBytes(testReportPath));
+
+    SnykTestResult snykTestResult = ObjectMapperHelper.unmarshallTestResult(testReport);
+
+    assertThat(snykTestResult.ok, equalTo(false));
+    assertThat(snykTestResult.dependencyCount, equalTo(6));
+    assertThat(snykTestResult.uniqueCount, equalTo(1));
+  }
+
+  @Test
+  public void unmarshallTestResult_multiModule_withoutVulns() throws IOException {
+    Path testReportPath = Paths.get(TEST_FIXTURES_DIRECTORY.getAbsolutePath(), "test", "multi-module-project", "snyk_report_without_vulns.json");
+    String testReport = new String(Files.readAllBytes(testReportPath));
+
+    SnykTestResult snykTestResult = ObjectMapperHelper.unmarshallTestResult(testReport);
+
+    assertThat(snykTestResult.ok, equalTo(true));
+    assertThat(snykTestResult.dependencyCount, equalTo(20));
+    assertThat(snykTestResult.uniqueCount, equalTo(0));
+  }
+}

--- a/src/test/resources/fixtures/monitor/snyk_monitor_with_uri.json
+++ b/src/test/resources/fixtures/monitor/snyk_monitor_with_uri.json
@@ -1,0 +1,11 @@
+{
+  "ok": true,
+  "org": "dummy-user",
+  "id": "long-id-as-uuid",
+  "isMonitored": true,
+  "uri": "http://localhost:8000/org/dummy-user/project/long-uuid-here/history/long-uuid-here-again",
+  "path": "/home/jenkins/projects/snyk-security-scanner-plugin",
+  "manageUrl": "http://localhost:8000/org/dummy-user/manage",
+  "packageManager": "maven",
+  "projectName": "io.snyk.plugins:snyk-security-scanner"
+}

--- a/src/test/resources/fixtures/monitor/snyk_monitor_without_uri.json
+++ b/src/test/resources/fixtures/monitor/snyk_monitor_without_uri.json
@@ -1,0 +1,5 @@
+{
+  "ok": false,
+  "error": "connect ECONNREFUSED 127.0.0.1:8000",
+  "path": "/home/jenkins/projects/snyk-security-scanner-plugin"
+}

--- a/src/test/resources/fixtures/test/multi-module-project/snyk_report_with_vulns.json
+++ b/src/test/resources/fixtures/test/multi-module-project/snyk_report_with_vulns.json
@@ -1,0 +1,194 @@
+[
+  {
+    "vulnerabilities": [],
+    "ok": true,
+    "dependencyCount": 0,
+    "org": "jenkins-junit-org",
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.14.0\nignore: {}\npatch: {}\n",
+    "isPrivate": true,
+    "licensesPolicy": {
+      "severities": {},
+      "orgLicenseRules": {}
+    },
+    "packageManager": "gradle",
+    "ignoreSettings": null,
+    "summary": "No known vulnerabilities",
+    "filesystemPolicy": false,
+    "uniqueCount": 0,
+    "path": "/home/jenkins/projects/multi-module-project"
+  },
+  {
+    "vulnerabilities": [
+      {
+        "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:F/RL:O",
+        "alternativeIds": [],
+        "creationTime": "2016-12-25T16:51:56Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 9.8,
+        "description": "## Overview\n\n[commons-collections:commons-collections](https://mvnrepository.com/artifact/commons-collections/commons-collections) is a library which contains types that extend and augment the Java Collections Framework.\n\n\nAffected versions of this package are vulnerable to Deserialization of Untrusted Data.\nIt is possible to execute arbitrary Java code with the `InvokerTransformer` serializable collections . The `sun.reflect.annotation.AnnotationInvocationHandler#readObject` method invokes `#entrySet` and `#get` on a deserialized collection. If an attacker has to ability to send serialized data (JMX, RMI, EJB) to an application using the `common-collections` library, it is possible to combine the aforementioned methods to execute arbitrary code on the application.\n\n## Details\nSerialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.\r\n\r\n  \r\n\r\n_Deserialization of untrusted data_ ([CWE-502](https://cwe.mitre.org/data/definitions/502.html)), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker to control the state or the flow of the execution.\r\n\r\n  \r\n\r\nJava deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a [popular library (Apache Commons Collection)](https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078). These classes were used in zero-days affecting IBM WebSphere, Oracle WebLogic and many other products.\r\n\r\n  \r\n\r\nAn attacker just needs to identify a piece of software that has both a vulnerable class on its path, and performs deserialization on untrusted data. Then all they need to do is send the payload into the deserializer, getting the command executed.\r\n\r\n  \r\n\r\n> Developers put too much trust in Java Object Serialization. Some even de-serialize objects pre-authentication. When deserializing an Object in Java you typically cast it to an expected type, and therefore Java's strict type system will ensure you only get valid object trees. Unfortunately, by the time the type checking happens, platform code has already created and executed significant logic. So, before the final type is checked a lot of code is executed from the readObject() methods of various objects, all of which is out of the developer's control. By combining the readObject() methods of various classes which are available on the classpath of the vulnerable application an attacker can execute functions (including calling Runtime.exec() to execute local OS commands).\r\n\r\n- Apache Blog\r\n\r\n  \r\n\r\nThe vulnerability, also know as _Mad Gadget_\r\n\r\n> Mad Gadget is one of the most pernicious vulnerabilities we’ve seen. By merely existing on the Java classpath, seven “gadget” classes in Apache Commons Collections (versions 3.0, 3.1, 3.2, 3.2.1, and 4.0) make object deserialization for the entire JVM process Turing complete with an exec function. Since many business applications use object deserialization to send messages across the network, it would be like hiring a bank teller who was trained to hand over all the money in the vault if asked to do so politely, and then entrusting that teller with the key. The only thing that would keep a bank safe in such a circumstance is that most people wouldn’t consider asking such a question.\r\n\r\n- Google\n\n## Remediation\n\nUpgrade `commons-collections:commons-collections` to version 3.2.2 or higher.\n\n\n## References\n\n- [FoxGloveSecurity Blog](http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/)\n\n- [GitHub Commit](https://github.com/apache/commons-collections/commit/e585cd0433ae4cfbc56e58572b9869bd0c86b611)\n\n- [Jira Issue](https://issues.apache.org/jira/browse/COLLECTIONS-580)\n",
+        "disclosureTime": "2015-11-06T16:51:56Z",
+        "exploit": "Functional",
+        "fixedIn": [
+          "3.2.2"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "className": "InvokerTransformer",
+              "filePath": "org/apache/commons/collections/functors/InvokerTransformer.java",
+              "functionName": "transform"
+            },
+            "version": [
+              "[3,3.2.2)"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "className": "org.apache.commons.collections.functors.InvokerTransformer",
+              "functionName": "transform"
+            },
+            "version": [
+              "[3,3.2.2)"
+            ]
+          }
+        ],
+        "id": "SNYK-JAVA-COMMONSCOLLECTIONS-30078",
+        "identifiers": {
+          "CVE": [
+            "CVE-2015-4852",
+            "CVE-2015-7501"
+          ],
+          "CWE": [
+            "CWE-502"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "commons-collections",
+          "groupId": "commons-collections"
+        },
+        "modificationTime": "2019-09-06T13:34:59.829115Z",
+        "moduleName": "commons-collections:commons-collections",
+        "packageManager": "maven",
+        "packageName": "commons-collections:commons-collections",
+        "patches": [],
+        "publicationTime": "2015-11-06T16:51:56Z",
+        "references": [
+          {
+            "title": "FoxGloveSecurity Blog",
+            "url": "http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/commons-collections/commit/e585cd0433ae4cfbc56e58572b9869bd0c86b611"
+          },
+          {
+            "title": "Jira Issue",
+            "url": "https://issues.apache.org/jira/browse/COLLECTIONS-580"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[3.0,3.2.2)"
+          ]
+        },
+        "severity": "high",
+        "title": "Deserialization of Untrusted Data",
+        "from": [
+          "123456789/gmg-api@0.0.0",
+          "commons-collections:commons-collections@3.1"
+        ],
+        "upgradePath": [
+          false,
+          "commons-collections:commons-collections@3.2.2"
+        ],
+        "isUpgradable": true,
+        "isPatchable": false,
+        "name": "commons-collections:commons-collections",
+        "version": "3.1"
+      }
+    ],
+    "ok": false,
+    "dependencyCount": 2,
+    "org": "jenkins-junit-org",
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.14.0\nignore: {}\npatch: {}\n",
+    "isPrivate": true,
+    "licensesPolicy": {
+      "severities": {
+      },
+      "orgLicenseRules": {
+      }
+    },
+    "packageManager": "gradle",
+    "ignoreSettings": null,
+    "summary": "1 vulnerable dependency path",
+    "remediation": {
+      "unresolved": [],
+      "upgrade": {
+        "commons-collections:commons-collections@3.1": {
+          "upgradeTo": "commons-collections:commons-collections@3.2.2",
+          "upgrades": [
+            "commons-collections:commons-collections@3.1"
+          ],
+          "vulns": [
+            "SNYK-JAVA-COMMONSCOLLECTIONS-30078"
+          ]
+        }
+      },
+      "patch": {},
+      "ignore": {},
+      "pin": {}
+    },
+    "filesystemPolicy": false,
+    "filtered": {
+      "ignore": [],
+      "patch": []
+    },
+    "uniqueCount": 1,
+    "path": "/home/jenkins/projects/multi-module-project"
+  },
+  {
+    "vulnerabilities": [],
+    "ok": true,
+    "dependencyCount": 2,
+    "org": "jenkins-junit-org",
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.14.0\nignore: {}\npatch: {}\n",
+    "isPrivate": true,
+    "licensesPolicy": {
+      "severities": {
+      },
+      "orgLicenseRules": {
+      }
+    },
+    "packageManager": "gradle",
+    "ignoreSettings": null,
+    "summary": "No known vulnerabilities",
+    "filesystemPolicy": false,
+    "uniqueCount": 0,
+    "path": "/opt/buildagent/work/"
+  },
+  {
+    "vulnerabilities": [],
+    "ok": true,
+    "dependencyCount": 2,
+    "org": "jenkins-junit-org",
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.14.0\nignore: {}\npatch: {}\n",
+    "isPrivate": true,
+    "licensesPolicy": {
+      "severities": {
+      },
+      "orgLicenseRules": {
+      }
+    },
+    "packageManager": "gradle",
+    "ignoreSettings": null,
+    "summary": "No known vulnerabilities",
+    "filesystemPolicy": false,
+    "uniqueCount": 0,
+    "path": "/home/jenkins/projects/multi-module-project"
+  }
+]

--- a/src/test/resources/fixtures/test/multi-module-project/snyk_report_without_vulns.json
+++ b/src/test/resources/fixtures/test/multi-module-project/snyk_report_without_vulns.json
@@ -1,0 +1,78 @@
+[
+  {
+    "vulnerabilities": [],
+    "ok": true,
+    "dependencyCount": 1,
+    "org": "jenkins-junit-org",
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.14.0\nignore: {}\npatch: {}\n",
+    "isPrivate": true,
+    "licensesPolicy": {
+      "severities": {},
+      "orgLicenseRules": {}
+    },
+    "packageManager": "gradle",
+    "ignoreSettings": null,
+    "summary": "No known vulnerabilities",
+    "filesystemPolicy": false,
+    "uniqueCount": 0,
+    "path": "/home/jenkins/projects/multi-module-project"
+  },
+  {
+    "vulnerabilities": [],
+    "ok": true,
+    "dependencyCount": 2,
+    "org": "jenkins-junit-org",
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.14.0\nignore: {}\npatch: {}\n",
+    "isPrivate": true,
+    "licensesPolicy": {
+      "severities": {},
+      "orgLicenseRules": {}
+    },
+    "packageManager": "gradle",
+    "ignoreSettings": null,
+    "summary": "No known vulnerabilities",
+    "filesystemPolicy": false,
+    "filtered": {
+      "ignore": [],
+      "patch": []
+    },
+    "uniqueCount": 0,
+    "path": "/home/jenkins/projects/multi-module-project"
+  },
+  {
+    "vulnerabilities": [],
+    "ok": true,
+    "dependencyCount": 15,
+    "org": "jenkins-junit-org",
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.14.0\nignore: {}\npatch: {}\n",
+    "isPrivate": true,
+    "licensesPolicy": {
+      "severities": {},
+      "orgLicenseRules": {}
+    },
+    "packageManager": "gradle",
+    "ignoreSettings": null,
+    "summary": "No known vulnerabilities",
+    "filesystemPolicy": false,
+    "uniqueCount": 0,
+    "path": "/home/jenkins/projects/multi-module-project"
+  },
+  {
+    "vulnerabilities": [],
+    "ok": true,
+    "dependencyCount": 2,
+    "org": "jenkins-junit-org",
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.14.0\nignore: {}\npatch: {}\n",
+    "isPrivate": true,
+    "licensesPolicy": {
+      "severities": {},
+      "orgLicenseRules": {}
+    },
+    "packageManager": "gradle",
+    "ignoreSettings": null,
+    "summary": "No known vulnerabilities",
+    "filesystemPolicy": false,
+    "uniqueCount": 0,
+    "path": "/home/jenkins/projects/multi-module-project"
+  }
+]

--- a/src/test/resources/fixtures/test/single-module-project/snyk_report_with_vulns.json
+++ b/src/test/resources/fixtures/test/single-module-project/snyk_report_with_vulns.json
@@ -1,0 +1,299 @@
+{
+  "vulnerabilities": [
+    {
+      "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "alternativeIds": [],
+      "creationTime": "2016-12-25T16:51:56Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 7.5,
+      "description": "## Overview\n[`commons-fileupload:commons-fileupload`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22commons-fileupload%22) provides a simple yet flexible means of adding support for multipart file upload functionality to servlets and web applications.\n\nAffected versions of this package are vulnerable to Denial of Service (DoS) attacks. An attacker can upload a file with a long boundry string in the HTTP header, causing high CPU consumption. The `MultipartStream` class contains a flaw that allows remote attackers to cause a Denial of service (CPU consumption) attacks. This happens by setting the length of the multipart boundary to be just below the size of the buffer (4096 bytes) used to read the uploaded file. Typically, the boundary is tens of bytes long, which caused this case to take much longer than usual.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\r\n\r\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\r\n\r\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\r\n\r\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\r\n\r\nTwo common types of DoS vulnerabilities:\r\n\r\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\r\n\r\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](npm:ws:20171108)\n\n## Remediation\nUpgrade `commons-fileupload:commons-fileupload` to version 1.3.2 or higher.\n\n## References\n- [Github ChangeLog](https://github.com/apache/commons-fileupload/blob/b1498c9877d751f8bc4635a6f252ebdfcba28518/src/changes/changes.xml#L84)\n- [Redhat Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=1349475)\n- [Apache Mailing Archives](http://mail-archives.us.apache.org/mod_mbox/www-announce/201606.mbox/%3C6223ece6-2b41-ef4f-22f9-d3481e492832@apache.org%3E)\n- [Apache-SVN](http://svn.apache.org/viewvc/commons/proper/fileupload/trunk/RELEASE-NOTES.txt?r1=1745717&r2=1749637&diff_format=h)\n- [CVE](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-3092)\n",
+      "disclosureTime": "2016-06-22T16:51:56Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "1.3.2"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-COMMONSFILEUPLOAD-30082",
+      "identifiers": {
+        "CVE": [
+          "CVE-2016-3092"
+        ],
+        "CWE": [
+          "CWE-20"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "commons-fileupload",
+        "groupId": "commons-fileupload"
+      },
+      "modificationTime": "2019-06-02T07:36:42.354413Z",
+      "moduleName": "commons-fileupload:commons-fileupload",
+      "packageManager": "maven",
+      "packageName": "commons-fileupload:commons-fileupload",
+      "patches": [],
+      "publicationTime": "2016-06-22T16:51:56Z",
+      "references": [
+        {
+          "title": "Apache Mailing Archives",
+          "url": "http://mail-archives.us.apache.org/mod_mbox/www-announce/201606.mbox/%3C6223ece6-2b41-ef4f-22f9-d3481e492832@apache.org%3E"
+        },
+        {
+          "title": "Apache-SVN",
+          "url": "http://svn.apache.org/viewvc/commons/proper/fileupload/trunk/RELEASE-NOTES.txt?r1=1745717&r2=1749637&diff_format=h"
+        },
+        {
+          "title": "CVE",
+          "url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-3092"
+        },
+        {
+          "title": "Github ChangeLog",
+          "url": "https://github.com/apache/commons-fileupload/blob/b1498c9877d751f8bc4635a6f252ebdfcba28518/src/changes/changes.xml%23L84"
+        },
+        {
+          "title": "Possible GitHub Commit",
+          "url": "https://github.com/apache/tomcat80/commit/d752a415a875e888d8c8d0988dfbde95c2c6fb1d"
+        },
+        {
+          "title": "Possible GitHub Commit",
+          "url": "https://github.com/apache/tomcat/commit/2c3553f3681baf775c50bb0b49ea61cb44ea914f"
+        },
+        {
+          "title": "Possible GitHub Commit",
+          "url": "https://github.com/apache/tomcat/commit/8999f8243197a5f8297d0cb1a0d86ed175678a77"
+        },
+        {
+          "title": "Redhat Bugzilla",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1349475"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[1.3,1.3.2)"
+        ]
+      },
+      "severity": "high",
+      "title": "Denial of Service (DoS)",
+      "from": [
+        "io.github.snyk:todolist-web-struts@0.0.1",
+        "org.apache.struts:struts2-core@2.3.20",
+        "commons-fileupload:commons-fileupload@1.3.1"
+      ],
+      "upgradePath": [
+        false,
+        "org.apache.struts:struts2-core@2.3.30",
+        "commons-fileupload:commons-fileupload@1.3.2"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "commons-fileupload:commons-fileupload",
+      "version": "1.3.1"
+    },
+    {
+      "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "alternativeIds": [],
+      "creationTime": "2017-02-22T07:28:18.753000Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 9.8,
+      "description": "## Overview\n[`commons-fileupload:commons-fileupload`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22commons-fileupload%22)\nThe Apache Commons FileUpload library contains a Java Object that, upon deserialization, can be manipulated to write or copy files in arbitrary locations. If integrated with [`ysoserial`](https://github.com/frohoff/ysoserial), it is possible to upload and execute binaries in a single deserialization call.\n\n# Details\nSerialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.\n\n_Deserialization of untrusted data_ ([CWE-502](https://cwe.mitre.org/data/definitions/502.html)), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker to control the state or the flow of the execution.\n\nJava deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a [popular library (Apache Commons Collection)](https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078). These classes were used in zero-days affecting IBM WebSphere, Oracle WebLogic and many other products.\n\nAn attacker just needs to identify a piece of software that has both a vulnerable class on its path, and performs deserialization on untrusted data. Then all they need to do is send the payload into the deserializer, getting the command executed.\n\n> Developers put too much trust in Java Object Serialization. Some even de-serialize objects pre-authentication. When deserializing an Object in Java you typically cast it to an expected type, and therefore Java's strict type system will ensure you only get valid object trees. Unfortunately, by the time the type checking happens, platform code has already created and executed significant logic. So, before the final type is checked a lot of code is executed from the readObject() methods of various objects, all of which is out of the developer's control. By combining the readObject() methods of various classes which are available on the classpath of the vulnerable application an attacker can execute functions (including calling Runtime.exec() to execute local OS commands).\n- Apache Blog\n\n## Remediation\nUpgrade `commons-fileupload` to version 1.3.3 or higher.\n\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-1000031)\n- [Tenable Security](http://www.tenable.com/security/research/tra-2016-12)\n- [Github ChangeLog](https://github.com/apache/commons-fileupload/blob/master/src/changes/changes.xml#L65)\n- [Github Commit](https://github.com/apache/commons-fileupload/commit/388e824518697c2c8f9f83fd964621d9c2f8fc4c)\n",
+      "disclosureTime": "2016-10-25T14:29:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "1.3.3"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": "DiskFileItem",
+            "filePath": "org/apache/commons/fileupload/disk/DiskFileItem.java",
+            "functionName": "readObject"
+          },
+          "version": [
+            "[1.1,1.3.3)"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "className": "org.apache.commons.fileupload.disk.DiskFileItem",
+            "functionName": "readObject"
+          },
+          "version": [
+            "[1.1,1.3.3)"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-COMMONSFILEUPLOAD-30401",
+      "identifiers": {
+        "CVE": [
+          "CVE-2016-1000031"
+        ],
+        "CWE": [
+          "CWE-284"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "commons-fileupload",
+        "groupId": "commons-fileupload"
+      },
+      "modificationTime": "2019-06-02T07:36:59.369724Z",
+      "moduleName": "commons-fileupload:commons-fileupload",
+      "packageManager": "maven",
+      "packageName": "commons-fileupload:commons-fileupload",
+      "patches": [],
+      "publicationTime": "2016-10-26T03:04:11.895000Z",
+      "references": [
+        {
+          "title": "Github ChangeLog",
+          "url": "https://github.com/apache/commons-fileupload/blob/master/src/changes/changes.xml%23L65"
+        },
+        {
+          "title": "Github Commit",
+          "url": "https://github.com/apache/commons-fileupload/commit/388e824518697c2c8f9f83fd964621d9c2f8fc4c"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-1000031"
+        },
+        {
+          "title": "Tenable Security",
+          "url": "http://www.tenable.com/security/research/tra-2016-12"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[1.1,1.3.3)"
+        ]
+      },
+      "severity": "high",
+      "title": "Arbitrary Code Execution",
+      "from": [
+        "io.github.snyk:todolist-web-struts@0.0.1",
+        "org.apache.struts:struts2-core@2.3.20",
+        "commons-fileupload:commons-fileupload@1.3.1"
+      ],
+      "upgradePath": [
+        false,
+        "org.apache.struts:struts2-core@2.3.37",
+        "commons-fileupload:commons-fileupload@1.4"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "commons-fileupload:commons-fileupload",
+      "version": "1.3.1"
+    },
+    {
+      "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N",
+      "alternativeIds": [],
+      "creationTime": "2017-10-01T08:05:48.497000Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 6.5,
+      "description": "## Overview\n[`commons-fileupload:commons-fileupload`](https://commons.apache.org/proper/commons-fileupload/) provides a simple yet flexible means of adding support for multipart file upload functionality to servlets and web applications.\n\nAffected versions of the package are vulnerable to Information Disclosure because the `InputStream` is not closed on exception.\n\n## Remediation\nUpgrade `commons-fileupload` to version 1.3.2 or higher.\n\n## References\n- [Github ChangeLog](https://github.com/apache/commons-fileupload/blob/master/src/changes/changes.xml#L56)\n- [Github Commit](https://github.com/apache/commons-fileupload/commit/5b4881d7f75f439326f54fa554a9ca7de6d60814)\n",
+      "disclosureTime": "2014-02-17T22:00:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "1.3.2"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": "FileUploadBase$FileItemIteratorImpl",
+            "filePath": "org/apache/commons/fileupload/FileUploadBase$FileItemIteratorImpl.java",
+            "functionName": "<init>"
+          },
+          "version": [
+            "[1.2.0 ,1.3.2)"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "className": "org.apache.commons.fileupload.FileUploadBase$FileItemIteratorImpl",
+            "functionName": "<init>"
+          },
+          "version": [
+            "[1.2.0 ,1.3.2)"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-COMMONSFILEUPLOAD-31540",
+      "identifiers": {
+        "CVE": [],
+        "CWE": [
+          "CWE-200"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "commons-fileupload",
+        "groupId": "commons-fileupload"
+      },
+      "modificationTime": "2019-03-20T14:28:31.441873Z",
+      "moduleName": "commons-fileupload:commons-fileupload",
+      "packageManager": "maven",
+      "packageName": "commons-fileupload:commons-fileupload",
+      "patches": [],
+      "publicationTime": "2017-02-17T08:05:48.497000Z",
+      "references": [
+        {
+          "title": "Github ChangeLog",
+          "url": "https://github.com/apache/commons-fileupload/blob/master/src/changes/changes.xml%23L56"
+        },
+        {
+          "title": "Github Commit",
+          "url": "https://github.com/apache/commons-fileupload/commit/5b4881d7f75f439326f54fa554a9ca7de6d60814"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,1.3.2)"
+        ]
+      },
+      "severity": "medium",
+      "title": "Information Disclosure",
+      "from": [
+        "io.github.snyk:todolist-web-struts@0.0.1",
+        "org.apache.struts:struts2-core@2.3.20",
+        "commons-fileupload:commons-fileupload@1.3.1"
+      ],
+      "upgradePath": [
+        false,
+        "org.apache.struts:struts2-core@2.3.30",
+        "commons-fileupload:commons-fileupload@1.3.2"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "commons-fileupload:commons-fileupload",
+      "version": "1.3.1"
+    }
+  ],
+  "ok": false,
+  "dependencyCount": 10,
+  "org": "jenkins-junit-org",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.14.0\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {}
+  },
+  "packageManager": "maven",
+  "ignoreSettings": null,
+  "summary": "3 vulnerable dependency paths",
+  "filesystemPolicy": false,
+  "filtered": {
+    "ignore": [],
+    "patch": []
+  },
+  "uniqueCount": 3,
+  "path": "/home/jenkins/projects/single-module-project"
+}

--- a/src/test/resources/fixtures/test/single-module-project/snyk_report_without_vulns.json
+++ b/src/test/resources/fixtures/test/single-module-project/snyk_report_without_vulns.json
@@ -1,0 +1,22 @@
+{
+  "vulnerabilities": [],
+  "ok": true,
+  "dependencyCount": 33,
+  "org": "jenkins-junit-org",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.14.0\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {}
+  },
+  "packageManager": "maven",
+  "ignoreSettings": null,
+  "summary": "No known vulnerabilities",
+  "filesystemPolicy": false,
+  "filtered": {
+    "ignore": [],
+    "patch": []
+  },
+  "uniqueCount": 0,
+  "path": "/home/jenkins/projects/single-module-project"
+}


### PR DESCRIPTION
This PR changes processing of json outputs (test and monitor commands).

We use now streaming API (instead of data binding to POJOs), this fixes issue with different format of `snyk test` command for single and multi-module projects (object vs array of objects).