### PR TITLE
fix: propagate exception to fail task if we fail to install the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,5 @@ To configure Jenkins to use experimental update site please follow this [tutoria
 ## Troubleshooting
 
 To troubleshoot the plugin, add a logger to capture all `io.snyk.jenkins` logs. Follow [this article](https://support.cloudbees.com/hc/en-us/articles/204880580-How-do-I-create-a-logger-in-Jenkins-for-troubleshooting-and-diagnostic-information-) to add a logger and re-run the Snyk Security job once again to capture logs.
+
+This plugin will attempt to download and install the Snyk CLI. If the installation of the Snyk CLI fails, your CI job will fail and you should see the error `Snyk Security tool could not installed` in the CI logs. If this is the case, it is likely either a permissions related mis-configuration on your Jenkins master or agents or a network issue.

--- a/src/main/java/io/snyk/jenkins/tools/SnykInstaller.java
+++ b/src/main/java/io/snyk/jenkins/tools/SnykInstaller.java
@@ -103,7 +103,7 @@ public class SnykInstaller extends ToolInstaller {
     }
   }
 
-  private FilePath installSnykAsNpmPackage(FilePath expected, Node node, TaskListener log) {
+  private FilePath installSnykAsNpmPackage(FilePath expected, Node node, TaskListener log) throws ToolDetectionException {
     LOG.info("Install Snyk version '{}' as NPM package on node '{}'", version, node.getDisplayName());
 
     ArgumentListBuilder args = new ArgumentListBuilder();
@@ -121,7 +121,7 @@ public class SnykInstaller extends ToolInstaller {
       expected.child(TIMESTAMP_FILE).write(valueOf(Instant.now().toEpochMilli()), UTF_8.name());
     } catch (Exception ex) {
       log.getLogger().println("Snyk Security tool could not installed: " + ex.getMessage());
-      LOG.error("Could not install Snyk as NPM package", ex);
+      throw new ToolDetectionException("Could not install Snyk CLI with npm", ex);
     }
     return expected;
   }
@@ -146,7 +146,7 @@ public class SnykInstaller extends ToolInstaller {
       expected.child(TIMESTAMP_FILE).write(valueOf(Instant.now().toEpochMilli()), UTF_8.name());
     } catch (Exception ex) {
       log.getLogger().println("Snyk Security tool could not installed: " + ex.getMessage());
-      LOG.error("Could not install Snyk as single binary", ex);
+      throw new ToolDetectionException("Could not install Snyk CLI from binary", ex);
     }
 
     return expected;

--- a/src/main/java/io/snyk/jenkins/tools/ToolDetectionException.java
+++ b/src/main/java/io/snyk/jenkins/tools/ToolDetectionException.java
@@ -11,4 +11,8 @@ class ToolDetectionException extends IOException {
   ToolDetectionException(String message) {
     super(message);
   }
+
+  ToolDetectionException(String message, Throwable innerException) {
+    super(message, innerException);
+  }
 }


### PR DESCRIPTION
This change catches and then re-throws an exception relating to not being able to install the Snyk CLI. This way it will cause a job to fail when the Snyk CLI cannot be installed.