### PR TITLE
Update Organization field description to indicate that it accepts ID, not name

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Enable the Snyk Security Scanner in the project configuration page. To add Snyk 
 - **Monitor project on build** - Take a current application dependencies snapshot for continuous monitoring by Snyk.
 - **Snyk token** - The ID for the API token from the Credentials plugin to be used to authenticate with Snyk (credential type must be "Snyk API token").
 - **Target file** - The path to the application manifest file to be scanned by Snyk Security Scanner.
-- **Organisation** - The Snyk organisation in which this project should be tested and monitored.
+- **Organization** - The ID of the Snyk organization in which this project should be tested and monitored.
 - **Project name** - A custom name for the Snyk project created for this Jenkins project on every build.
 
 #### Advanced Configuration
@@ -77,7 +77,7 @@ The `snykSecurity` function accepts the following parameters:
 - **snykTokenId** - The ID of the API token from the Credentials plugin to be used to authenticate to Snyk.
 - **additionalArguments** (optional, default **none**) - Refer to the [Snyk CLI](https://snyk.io/docs/using-snyk/) help page for information on additional arguments.
 - **failOnIssues** (optional, default **true**) - This specifies if builds should be failed or continued based on issues found by Snyk.
-- **organisation** (optional, default **none**) - The Snyk organisation in which this project should be tested and monitored.
+- **organisation** (optional, default **none**) - The ID of the Snyk organization in which this project should be tested and monitored.
 - **projectName** (optional, default **none**) - A custom name for the Snyk project created for this Jenkins project on every build.
 - **severity** (optional, default **low**) - Only report vulnerabilities of provided level or higher (low/medium/high). Default is low.
 - **targetFile** (optional, default **none**) - The path to the manifest file to be used by Snyk.

--- a/src/main/resources/io/snyk/jenkins/SnykStepBuilder/config.jelly
+++ b/src/main/resources/io/snyk/jenkins/SnykStepBuilder/config.jelly
@@ -36,7 +36,7 @@
     <f:entry title="Target file" field="targetFile">
       <f:textbox/>
     </f:entry>
-    <f:entry title="Organisation" field="organisation">
+    <f:entry title="Organization" field="organisation">
       <f:textbox/>
     </f:entry>
     <f:entry title="Project name" field="projectName">

--- a/src/main/resources/io/snyk/jenkins/SnykStepBuilder/help-organisation.html
+++ b/src/main/resources/io/snyk/jenkins/SnykStepBuilder/help-organisation.html
@@ -1,6 +1,6 @@
 <div>
   <p>
-    The Snyk organisation in which this project should be tested and monitored. Leave empty to use your default organisation.
+    The ID of the Snyk organization in which this project should be tested and monitored. Leave empty to use your default organization.
   </p>
   <p>
     The corresponding CLI option for this parameter: <strong>--org</strong>


### PR DESCRIPTION
### What was done
The description for the Organization field was updated to indicate that this field accepts organization ID, not its name. Because the current description make some confusion, and when you specify the name instead of the ID, Snyk fails with the following error, which does not describe the actual problem:
> Error result: We couldn't test `project name`. Please check the version and package name and try running `snyk test` again.

### Suggestion
It makes sense to change the word organi**s**ation to organi**z**ation (with `z`) all over the project because **Snyk** uses organi**z**ation word in its descriptions and documentation:
![image](https://user-images.githubusercontent.com/10218528/92282027-809eff00-ef05-11ea-9922-688baeb8144d.png)

Google trends for **organization** and **organisation**:
https://trends.google.com/trends/explore?q=organization,organisation