### PR TITLE
Generate unique reports per project

### DIFF
--- a/src/main/java/io/snyk/jenkins/workflow/SnykSecurityStep.java
+++ b/src/main/java/io/snyk/jenkins/workflow/SnykSecurityStep.java
@@ -433,7 +433,7 @@ public class SnykSecurityStep extends Step {
         if (build.getActions(SnykReportBuildAction.class).isEmpty()) {
           build.addAction(new SnykReportBuildAction(build));
         }
-        ArtifactArchiver artifactArchiver = new ArtifactArchiver(workspace.getName() + "_" + SNYK_REPORT_HTML);
+        ArtifactArchiver artifactArchiver = new ArtifactArchiver(workspace.getName() + "_" + getHtmlReportFileName());
         artifactArchiver.perform(build, workspace, launcher, log);
       } catch (IOException ex) {
         Util.displayIOException(ex, log);
@@ -500,6 +500,15 @@ public class SnykSecurityStep extends Step {
       return args;
     }
 
+    private String getHtmlReportFileName(){
+      if(fixEmptyAndTrim(snykSecurityStep.projectName) != null){
+        return snykSecurityStep.projectName + "_" + SNYK_REPORT_HTML;
+      }
+      else{
+        return SNYK_REPORT_HTML;
+      }
+    }
+
     private void generateSnykHtmlReport(Run<?, ?> build, @Nonnull FilePath workspace, Launcher launcher, TaskListener log, String reportExecutable, String monitorUri) throws IOException, InterruptedException {
       EnvVars env = build.getEnvironment(log);
       ArgumentListBuilder args = new ArgumentListBuilder();
@@ -510,10 +519,10 @@ public class SnykSecurityStep extends Step {
         return;
       }
 
-      workspace.child(SNYK_REPORT_HTML).write("", UTF_8.name());
+      workspace.child(getHtmlReportFileName()).write("", UTF_8.name());
 
       args.add(reportExecutable);
-      args.add("-i", SNYK_TEST_REPORT_JSON, "-o", SNYK_REPORT_HTML);
+      args.add("-i", SNYK_TEST_REPORT_JSON, "-o", getHtmlReportFileName());
       try {
         int exitCode = launcher.launch()
                                .cmds(args)
@@ -525,10 +534,10 @@ public class SnykSecurityStep extends Step {
         if (!success) {
           log.getLogger().println("Generating Snyk html report was not successful");
         }
-        String reportWithInlineCSS = workspace.child(SNYK_REPORT_HTML).readToString();
+        String reportWithInlineCSS = workspace.child(getHtmlReportFileName()).readToString();
         String modifiedHtmlReport = ReportConverter.getInstance().modifyHeadSection(reportWithInlineCSS);
         String finalHtmlReport = ReportConverter.getInstance().injectMonitorLink(modifiedHtmlReport, monitorUri);
-        workspace.child(workspace.getName() + "_" + SNYK_REPORT_HTML).write(finalHtmlReport, UTF_8.name());
+        workspace.child(workspace.getName() + "_" + getHtmlReportFileName()).write(finalHtmlReport, UTF_8.name());
       } catch (IOException ex) {
         Util.displayIOException(ex, log);
         ex.printStackTrace(log.fatalError("Snyk-to-Html command execution failed"));


### PR DESCRIPTION
**What was done**

When we have more than one project being scanned in the same Jenkins pipeline, due to the fact that html report generated with the same name at the end we only get access to the last report as each one rewrites the already existing report.

**Suggestion**
I guess its better to generate and archive reports with unique name (using `projectName`), so that there wont any reports missing.