### PR TITLE
fix: check for NPE by marshalling/unmarshalling json objects

### DIFF
--- a/src/main/java/io/snyk/jenkins/model/ObjectMapperHelper.java
+++ b/src/main/java/io/snyk/jenkins/model/ObjectMapperHelper.java
@@ -26,7 +26,7 @@ public class ObjectMapperHelper {
     }
 
     try (JsonParser parser = JSON_FACTORY.createParser(content)) {
-      if (parser.nextToken() != JsonToken.START_OBJECT) {
+      if (parser == null || parser.nextToken() != JsonToken.START_OBJECT) {
         return null;
       }
 
@@ -52,6 +52,10 @@ public class ObjectMapperHelper {
 
     try (JsonParser parser = JSON_FACTORY.createParser(content)) {
       JsonToken token = parser.nextToken();
+      if (token == null) {
+        return null;
+      }
+
       if (token == JsonToken.START_ARRAY) {
         List<SnykTestResult> testStatuses = new ArrayList<>();
         while (parser.nextToken() != JsonToken.END_ARRAY) {


### PR DESCRIPTION
This PR fixes all SpotBugs findings after upgrading Jenkins Core version from 2.63 to 2.176.4.

SpotBug findings from console:
```
[ERROR] Nullcheck of parser at line 29 of value previously dereferenced in
    io.snyk.jenkins.model.ObjectMapperHelper.unmarshallMonitorResult(String)
    [io.snyk.jenkins.model.ObjectMapperHelper, io.snyk.jenkins.model.ObjectMapperHelper]
    At ObjectMapperHelper.java:[line 29]Redundant null check at ObjectMapperHelper.java:[line 45] 
    RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE
[ERROR] Nullcheck of parser at line 54 of value previously dereferenced in
    io.snyk.jenkins.model.ObjectMapperHelper.unmarshallTestResult(String)
    [io.snyk.jenkins.model.ObjectMapperHelper,  io.snyk.jenkins.model.ObjectMapperHelper]
    At ObjectMapperHelper.java:[line 54]Redundant null check at ObjectMapperHelper.java:[line 66]
    RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE
```

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Please describe what you did

<!--
Put an `x` into the [ ] to show you have filled the information
-->
