### PR TITLE
chore: upgrade to plugin-pom v4.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.40</version>
+    <version>4.19</version>
   </parent>
   <groupId>io.snyk.plugins</groupId>
   <artifactId>snyk-security-scanner</artifactId>


### PR DESCRIPTION
Jenkins documentation suggests we use a recent version of the parent pom.

https://www.jenkins.io/doc/developer/plugin-development/updating-parent/

So I'm upgrading to latest (4.19 as of writing). 4.x only supports versions 2.164.x and above, but since we support 2.176.4 and above, no changes need to be made on our end.