### PR TITLE
chore: upgrade maven wrapper to 3.8.1

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip


### PR DESCRIPTION
The current Maven wrapper we're using has less useful debug output when for example it fails to install dependencies due to a HTTP -> HTTPS redirect. Newer versions provide more useful information like the specific dependency that needs to be updated. There are probably more improvements like this in newer versions.

This does not affect our production version support. This is just for development.