### PR TITLE
feat: remove npm install process, only use binaries

### DIFF
--- a/src/main/java/io/snyk/jenkins/tools/SnykInstallation.java
+++ b/src/main/java/io/snyk/jenkins/tools/SnykInstallation.java
@@ -1,13 +1,5 @@
 package io.snyk.jenkins.tools;
 
-import javax.annotation.Nonnull;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Collections;
-import java.util.List;
-
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher;
@@ -26,6 +18,13 @@ import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+
 import static java.lang.String.format;
 
 public class SnykInstallation extends ToolInstallation implements EnvironmentSpecific<SnykInstallation>, NodeSpecific<SnykInstallation> {
@@ -33,14 +32,6 @@ public class SnykInstallation extends ToolInstallation implements EnvironmentSpe
   @DataBoundConstructor
   public SnykInstallation(@Nonnull String name, @Nonnull String home, List<? extends ToolProperty<?>> properties) {
     super(name, home, properties);
-  }
-
-  @Override
-  public void buildEnvVars(EnvVars env) {
-    String root = getHome();
-    if (root != null) {
-      env.put("PATH+SNYK_HOME", new File(root, "node_modules/.bin").toString());
-    }
   }
 
   @Override
@@ -74,39 +65,16 @@ public class SnykInstallation extends ToolInstallation implements EnvironmentSpe
   }
 
   private String resolveExecutable(String file, Platform platform) throws IOException {
-    final Path nodeModulesBin = getNodeModulesBin();
-    if (nodeModulesBin != null) {
-      final Path executable = nodeModulesBin.resolve(file);
-      if (!executable.toFile().exists()) {
-        throw new IOException(format("Could not find executable <%s>", executable));
-      }
-      return executable.toAbsolutePath().toString();
-    } else {
-      String root = getHome();
-      if (root == null) {
-        return null;
-      }
-      String wrapperFileName = "snyk".equals(file) ? platform.snykWrapperFileName : platform.snykToHtmlWrapperFileName;
-      final Path executable = Paths.get(root).resolve(wrapperFileName);
-      if (!executable.toFile().exists()) {
-        throw new IOException(format("Could not find executable <%s>", wrapperFileName));
-      }
-      return executable.toAbsolutePath().toString();
-    }
-  }
-
-  private Path getNodeModulesBin() {
     String root = getHome();
     if (root == null) {
       return null;
     }
-
-    Path nodeModules = Paths.get(root).resolve("node_modules").resolve(".bin");
-    if (!nodeModules.toFile().exists()) {
-      return null;
+    String wrapperFileName = "snyk".equals(file) ? platform.snykWrapperFileName : platform.snykToHtmlWrapperFileName;
+    final Path executable = Paths.get(root).resolve(wrapperFileName);
+    if (!executable.toFile().exists()) {
+      throw new IOException(format("Could not find executable <%s>", wrapperFileName));
     }
-
-    return nodeModules;
+    return executable.toAbsolutePath().toString();
   }
 
   @Extension

--- a/src/main/java/io/snyk/jenkins/tools/internal/DownloadService.java
+++ b/src/main/java/io/snyk/jenkins/tools/internal/DownloadService.java
@@ -1,49 +1,24 @@
 package io.snyk.jenkins.tools.internal;
 
+import io.snyk.jenkins.tools.Platform;
+
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.net.URL;
 
-import io.snyk.jenkins.tools.Platform;
-import net.sf.json.JSONObject;
-import org.apache.commons.io.IOUtils;
-
 import static java.lang.String.format;
 
 public class DownloadService {
-
-  private static final String SNYK_RELEASES_LATEST = "https://api.github.com/repos/snyk/snyk/releases/latest";
-  private static final String SNYK_RELEASES_TAGS = "https://api.github.com/repos/snyk/snyk/releases/tags/v%s";
-  private static final String SNYK_HTML_RELEASES_LATEST = "https://api.github.com/repos/snyk/snyk-to-html/releases/latest";
 
   private DownloadService() {
     // squid:S1118
   }
 
   public static URL getDownloadUrlForSnyk(@Nonnull String version, @Nonnull Platform platform) throws IOException {
-    String jsonString;
-    String tagName;
-
-    // latest version needed different url
-    if ("latest".equals(version)) {
-      jsonString = loadJSON(SNYK_RELEASES_LATEST);
-    } else {
-      jsonString = loadJSON(format(SNYK_RELEASES_TAGS, version));
-    }
-    JSONObject release = JSONObject.fromObject(jsonString);
-    tagName = (String) release.get("tag_name");
-    return new URL(format("https://github.com/snyk/snyk/releases/download/%s/%s", tagName, platform.snykWrapperFileName));
+    return new URL(format("https://static.snyk.io/cli/%s/%s", version, platform.snykWrapperFileName));
   }
 
-  public static URL getDownloadUrlForSnykToHtml(@Nonnull Platform platform) throws IOException {
-    String jsonString = loadJSON(SNYK_HTML_RELEASES_LATEST);
-    JSONObject release = JSONObject.fromObject(jsonString);
-    String tagName = (String) release.get("tag_name");
-    return new URL(format("https://github.com/snyk/snyk-to-html/releases/download/%s/%s", tagName, platform.snykToHtmlWrapperFileName));
-  }
-
-  private static String loadJSON(String source) throws IOException {
-    final URL sourceUrl = new URL(source);
-    return IOUtils.toString(sourceUrl, "UTF-8");
+  public static URL getDownloadUrlForSnykToHtml(@Nonnull String version, @Nonnull Platform platform) throws IOException {
+    return new URL(format("https://static.snyk.io/snyk-to-html/%s/%s", version, platform.snykToHtmlWrapperFileName));
   }
 }


### PR DESCRIPTION
The npm install process requires the user to setup a supported NodeJS and NPM version  which often causes friction. If we only support binaries we can guarantee the install works without requiring the user to manually setup their NodeJS environment and keeping it up-to-date.