### PR TITLE
fix: upgrade vulnerable credentials plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,6 @@
 buildPlugin(configurations: [
   [ platform: "linux", jdk: "8" ],
   [ platform: "windows", jdk: "8" ],
-  [ platform: "linux", jdk: "8", jenkins: "2.176.4", javaLabel: 8 ],
-  [ platform: "windows", jdk: "8", jenkins: "2.176.4", javaLabel: 8 ]
+  [ platform: "linux", jdk: "8", jenkins: "2.222.4", javaLabel: 8 ],
+  [ platform: "windows", jdk: "8", jenkins: "2.222.4", javaLabel: 8 ]
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   </licenses>
 
   <properties>
-    <jenkins.version>2.176.4</jenkins.version>
+    <jenkins.version>2.222.4</jenkins.version>
     <java.level>8</java.level>
     <surefire.rerunFailingTestsCount>0</surefire.rerunFailingTestsCount>
   </properties>
@@ -48,12 +48,12 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>symbol-annotation</artifactId>
-      <version>1.20</version>
+      <version>1.23</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.3.11</version>
+      <version>2.5</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
The Credentials Plugin v2.3.11 we're using has vulnerabilities. https://snyk.io/vuln/SNYK-JAVA-ORGJENKINSCIPLUGINS-1292149

Releases v2.3.12 and above that fix this vulnerability only support Jenkins v2.222.4 and above. So we need to also increase our minimum version support from v2.176.4 to v2.222.4.

Looking at statistics: https://stats.jenkins.io/pluginversions/snyk-security-scanner.html

We can drop support for lower versions as users are free to use older versions and only 3 users seem to be using the latest Snyk Security Scanner v2.13.0 on Jenkins versions below v2.222.4.

As a side note, we also had to update `symbol-annotation` for compatibility with newer Credentials Plugin.