### PR TITLE
chore: migrate deprecated Jenkins.getInstance calls

### DIFF
--- a/src/main/java/io/snyk/jenkins/tools/SnykInstallation.java
+++ b/src/main/java/io/snyk/jenkins/tools/SnykInstallation.java
@@ -126,14 +126,12 @@ public class SnykInstallation extends ToolInstallation implements EnvironmentSpe
 
     @Override
     public SnykInstallation[] getInstallations() {
-      Jenkins instance = Jenkins.getInstance();
-      return instance.getDescriptorByType(SnykStepBuilderDescriptor.class).getInstallations();
+      return Jenkins.get().getDescriptorByType(SnykStepBuilderDescriptor.class).getInstallations();
     }
 
     @Override
     public void setInstallations(SnykInstallation... installations) {
-      Jenkins instance = Jenkins.getInstance();
-      instance.getDescriptorByType(SnykStepBuilderDescriptor.class).setInstallations(installations);
+      Jenkins.get().getDescriptorByType(SnykStepBuilderDescriptor.class).setInstallations(installations);
     }
   }
 }

--- a/src/main/java/io/snyk/jenkins/workflow/SnykSecurityStep.java
+++ b/src/main/java/io/snyk/jenkins/workflow/SnykSecurityStep.java
@@ -443,7 +443,7 @@ public class SnykSecurityStep extends Step {
     }
 
     private SnykInstallation findSnykInstallation() {
-      SnykStepBuilderDescriptor descriptor = Jenkins.getInstance().getDescriptorByType(SnykStepBuilderDescriptor.class);
+      SnykStepBuilderDescriptor descriptor = Jenkins.get().getDescriptorByType(SnykStepBuilderDescriptor.class);
       return Stream.of(descriptor.getInstallations())
                    .filter(installation -> installation.getName().equals(snykSecurityStep.snykInstallation))
                    .findFirst().orElse(null);


### PR DESCRIPTION
The SpotBugs integration we use in PR checks complains about using deprecated methods like `Jenkins.getInstance`. So I've migrated to `Jenkins.get` which will throw with details for troubleshooting if the result is `null`, which is better than what we currently do which is to assume it isn't `null` and potentially throw a generic `NullPointerException`.