### PR TITLE
chore: use individuals for codeowners as jenkins org doesn't have our teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/hammer
+* @Avishagp @JackuB @jahed-snyk @maxjeffos # @snyk/hammer


### PR DESCRIPTION
Currently when creating PRs, Team Hammer isn't auto assigned for reviews. This is because GitHub doesn't match `@snyk/hammer` to the Hammer team in @snyk's organisation. So I've added use individually.