### PR TITLE
fix: include context path when hyperlinking to css

### DIFF
--- a/src/main/java/io/snyk/jenkins/SnykStepBuilder.java
+++ b/src/main/java/io/snyk/jenkins/SnykStepBuilder.java
@@ -406,7 +406,7 @@ public class SnykStepBuilder extends Builder {
         log.getLogger().println("Generating Snyk html report was not successful");
       }
       String reportWithInlineCSS = workspace.child(SNYK_REPORT_HTML).readToString();
-      String modifiedHtmlReport = ReportConverter.getInstance().modifyHeadSection(reportWithInlineCSS);
+      String modifiedHtmlReport = ReportConverter.getInstance().modifyHeadSection(reportWithInlineCSS, Jenkins.get().servletContext.getContextPath());
       String finalHtmlReport = ReportConverter.getInstance().injectMonitorLink(modifiedHtmlReport, monitorUri);
       workspace.child(workspace.getName() + "_" + SNYK_REPORT_HTML).write(finalHtmlReport, UTF_8.name());
     } catch (IOException ex) {

--- a/src/main/java/io/snyk/jenkins/workflow/SnykSecurityStep.java
+++ b/src/main/java/io/snyk/jenkins/workflow/SnykSecurityStep.java
@@ -505,7 +505,7 @@ public class SnykSecurityStep extends Step {
           log.getLogger().println("Generating Snyk html report was not successful");
         }
         String reportWithInlineCSS = workspace.child(SNYK_REPORT_HTML).readToString();
-        String modifiedHtmlReport = ReportConverter.getInstance().modifyHeadSection(reportWithInlineCSS);
+        String modifiedHtmlReport = ReportConverter.getInstance().modifyHeadSection(reportWithInlineCSS, Jenkins.get().servletContext.getContextPath());
         String finalHtmlReport = ReportConverter.getInstance().injectMonitorLink(modifiedHtmlReport, monitorUri);
         workspace.child(workspace.getName() + "_" + SNYK_REPORT_HTML).write(finalHtmlReport, UTF_8.name());
       } catch (IOException ex) {

--- a/src/test/java/io/snyk/jenkins/transform/ReportConverterTest.java
+++ b/src/test/java/io/snyk/jenkins/transform/ReportConverterTest.java
@@ -2,47 +2,50 @@ package io.snyk.jenkins.transform;
 
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertThat;
 
 public class ReportConverterTest {
 
-  private ReportConverter converter = ReportConverter.getInstance();
-
   @Test
   public void modifyHeadSection_shouldNotChangeHtml_ifHeadTagNotExists() {
-    String inputHtml = "<html><body>text</body></html>";
-    String outputHtml = converter.modifyHeadSection(inputHtml, "/jenkins");
+    ReportConverter converter = ReportConverter.getInstance();
+    String input = "<html><body>text</body></html>";
 
-    assertThat(outputHtml, equalTo(inputHtml));
+    String output = converter.modifyHeadSection(input, "/jenkins");
+
+    assertThat(output, equalTo(input));
   }
 
   @Test
   public void modifyHeadSection_shouldAddExternalCssLink_ifHeadTagExists() {
-    String expectedHtml = "<html><head><link rel=\"stylesheet\" href=\"/jenkins/plugin/snyk-security-scanner/css/snyk_report.css\"></head><body>text</body></html>";
-    String inputHtml = "<html><head></head><body>text</body></html>";
+    ReportConverter converter = ReportConverter.getInstance();
+    String input = "<html><head></head><body>text</body></html>";
 
-    String outputHtml = converter.modifyHeadSection(inputHtml, "/jenkins");
+    String output = converter.modifyHeadSection(input, "/jenkins");
 
-    assertThat(outputHtml, equalTo(expectedHtml));
+    String expected = "<html><head><link rel=\"stylesheet\" href=\"/jenkins/plugin/snyk-security-scanner/css/snyk_report.css\"></head><body>text</body></html>";
+    assertThat(output, equalTo(expected));
   }
 
   @Test
   public void injectMonitorLink_shouldNotChangeHtml_ifMonitorUriIsEmpty() {
-    String inputHtml = "<html><head></head><body>report text</body></html>";
+    ReportConverter converter = ReportConverter.getInstance();
+    String input = "<html><head></head><body>report text</body></html>";
 
-    String outputHtml = converter.injectMonitorLink(inputHtml, "");
+    String output = converter.injectMonitorLink(input, "");
 
-    assertThat(outputHtml, equalTo(inputHtml));
+    assertThat(output, equalTo(input));
   }
 
   @Test
   public void injectMonitorLink_shouldAddMonitorLink_ifMonitorUriIsNotEmpty() {
-    String expectedHtml = "<html><head></head><body><center><a target=\"_blank\" href=\"https://app.snyk.io/my-monitor-report\">View On Snyk.io</a></center>report text</body></html>";
-    String inputHtml = "<html><head></head><body>report text</body></html>";
+    ReportConverter converter = ReportConverter.getInstance();
+    String input = "<html><head></head><body>report text</body></html>";
 
-    String outputHtml = converter.injectMonitorLink(inputHtml, "https://app.snyk.io/my-monitor-report");
+    String output = converter.injectMonitorLink(input, "https://app.snyk.io/my-monitor-report");
 
-    assertThat(outputHtml, equalTo(expectedHtml));
+    String expected = "<html><head></head><body><center><a target=\"_blank\" href=\"https://app.snyk.io/my-monitor-report\">View On Snyk.io</a></center>report text</body></html>";
+    assertThat(output, equalTo(expected));
   }
 }

--- a/src/test/java/io/snyk/jenkins/transform/ReportConverterTest.java
+++ b/src/test/java/io/snyk/jenkins/transform/ReportConverterTest.java
@@ -12,18 +12,17 @@ public class ReportConverterTest {
   @Test
   public void modifyHeadSection_shouldNotChangeHtml_ifHeadTagNotExists() {
     String inputHtml = "<html><body>text</body></html>";
-
-    String outputHtml = converter.modifyHeadSection(inputHtml);
+    String outputHtml = converter.modifyHeadSection(inputHtml, "/jenkins");
 
     assertThat(outputHtml, equalTo(inputHtml));
   }
 
   @Test
   public void modifyHeadSection_shouldAddExternalCssLink_ifHeadTagExists() {
-    String expectedHtml = "<html><head><link rel=\"stylesheet\" href=\"/plugin/snyk-security-scanner/css/snyk_report.css\"></head><body>text</body></html>";
+    String expectedHtml = "<html><head><link rel=\"stylesheet\" href=\"/jenkins/plugin/snyk-security-scanner/css/snyk_report.css\"></head><body>text</body></html>";
     String inputHtml = "<html><head></head><body>text</body></html>";
 
-    String outputHtml = converter.modifyHeadSection(inputHtml);
+    String outputHtml = converter.modifyHeadSection(inputHtml, "/jenkins");
 
     assertThat(outputHtml, equalTo(expectedHtml));
   }


### PR DESCRIPTION
Currently we assume that Jenkins is running on the root of the host. e.g. `https://jenkins.snyk.io/`, but by default Jenkins runs on `https://jenkins.snyk.io/jenkins` and it can be configured to any prefix by the user using `--prefix` when launching Jenkins. This means if the user isn't running on the root our CSS will not be found and the report will be unstyled.

In the future, this can be improved to avoid hardcoding CSS in this plugin and potentially going out of sync with snyk-to-html. We can extract the CSS and generate a `snyk_report.css` alongside the `snyk_report.html` so they're always in sync with whichever version of snyk-to-html is used.

# Before

<img width="951" alt="Screenshot 2021-06-15 at 13 41 28" src="https://user-images.githubusercontent.com/79453381/122054252-67ee3e80-cddf-11eb-9af7-d7edbd25cb59.png">

# After

<img width="915" alt="Screenshot 2021-06-15 at 13 41 22" src="https://user-images.githubusercontent.com/79453381/122054256-691f6b80-cddf-11eb-967e-1dcb5a2bda12.png">
