### PR TITLE
refactor: make steps as similar as possible 

### DIFF
--- a/src/main/java/io/snyk/jenkins/CLIArgs.java
+++ b/src/main/java/io/snyk/jenkins/CLIArgs.java
@@ -1,0 +1,45 @@
+package io.snyk.jenkins;
+
+import hudson.EnvVars;
+import hudson.util.ArgumentListBuilder;
+
+import javax.annotation.Nonnull;
+
+import static hudson.Util.*;
+
+public class CLIArgs {
+  public static ArgumentListBuilder buildArgumentList(
+    String snykExecutable,
+    String snykCommand,
+    @Nonnull EnvVars env,
+    Severity severity,
+    String targetFile,
+    String organisation,
+    String projectName,
+    String additionalArguments
+  ) {
+    ArgumentListBuilder args = new ArgumentListBuilder(snykExecutable, snykCommand, "--json");
+
+    if (severity != null && fixEmptyAndTrim(severity.getSeverity()) != null) {
+      args.add("--severity-threshold=" + severity.getSeverity());
+    }
+    if (fixEmptyAndTrim(targetFile) != null) {
+      args.add("--file=" + replaceMacro(targetFile, env));
+    }
+    if (fixEmptyAndTrim(organisation) != null) {
+      args.add("--org=" + replaceMacro(organisation, env));
+    }
+    if (fixEmptyAndTrim(projectName) != null) {
+      args.add("--project-name=" + replaceMacro(projectName, env));
+    }
+    if (fixEmptyAndTrim(additionalArguments) != null) {
+      for (String addArg : tokenize(additionalArguments)) {
+        if (fixEmptyAndTrim(addArg) != null) {
+          args.add(replaceMacro(addArg, env));
+        }
+      }
+    }
+
+    return args;
+  }
+}

--- a/src/main/java/io/snyk/jenkins/SnykMonitor.java
+++ b/src/main/java/io/snyk/jenkins/SnykMonitor.java
@@ -1,0 +1,89 @@
+package io.snyk.jenkins;
+
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.util.ArgumentListBuilder;
+import io.snyk.jenkins.model.ObjectMapperHelper;
+import io.snyk.jenkins.model.SnykMonitorResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.util.Optional;
+
+import static hudson.Util.fixEmptyAndTrim;
+import static io.snyk.jenkins.CLIArgs.buildArgumentList;
+import static io.snyk.jenkins.config.SnykConstants.SNYK_MONITOR_REPORT_JSON;
+
+public class SnykMonitor {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SnykMonitor.class.getName());
+
+  public static Optional<String> execute(
+    FilePath workspace,
+    Launcher launcher,
+    EnvVars envVars,
+    PrintStream logger,
+    String snykExecutable,
+    Severity severity,
+    String targetFile,
+    String organisation,
+    String projectName,
+    String additionalArguments
+  )
+  throws IOException, InterruptedException {
+    FilePath snykMonitorReport = workspace.child(SNYK_MONITOR_REPORT_JSON);
+    FilePath snykMonitorDebug = workspace.child(SNYK_MONITOR_REPORT_JSON + ".debug");
+
+    ArgumentListBuilder argsForMonitorCommand = buildArgumentList(
+      snykExecutable,
+      "monitor",
+      envVars,
+      severity,
+      targetFile,
+      organisation,
+      projectName,
+      additionalArguments
+    );
+
+    logger.println("Remember project for continuous monitoring...");
+    logger.println("> " + argsForMonitorCommand);
+
+    int monitorExitCode;
+    try (
+      OutputStream snykMonitorOutput = snykMonitorReport.write();
+      OutputStream snykMonitorDebugOutput = snykMonitorDebug.write()
+    ) {
+      monitorExitCode = launcher.launch()
+        .cmds(argsForMonitorCommand)
+        .envs(envVars)
+        .stdout(snykMonitorOutput)
+        .stderr(snykMonitorDebugOutput)
+        .quiet(true)
+        .pwd(workspace)
+        .join();
+    }
+    String snykMonitorReportAsString = snykMonitorReport.readToString();
+    if (monitorExitCode != 0) {
+      logger.println("Warning: 'snyk monitor' was not successful. Exit code: " + monitorExitCode);
+      logger.println(snykMonitorReportAsString);
+    }
+
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("Command line arguments: {}", argsForMonitorCommand);
+      LOG.trace("Exit code: {}", monitorExitCode);
+      LOG.trace("Command standard output: {}", snykMonitorReportAsString);
+      LOG.trace("Command debug output: {}", snykMonitorDebug.readToString());
+    }
+
+    SnykMonitorResult snykMonitorResult = ObjectMapperHelper.unmarshallMonitorResult(snykMonitorReportAsString);
+    if (snykMonitorResult != null && fixEmptyAndTrim(snykMonitorResult.uri) != null) {
+      logger.println("Explore the snapshot at " + snykMonitorResult.uri);
+      return Optional.of(snykMonitorResult.uri);
+    }
+    return Optional.empty();
+  }
+}

--- a/src/main/java/io/snyk/jenkins/SnykToHTML.java
+++ b/src/main/java/io/snyk/jenkins/SnykToHTML.java
@@ -1,0 +1,61 @@
+package io.snyk.jenkins;
+
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.Util;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.util.ArgumentListBuilder;
+import io.snyk.jenkins.transform.ReportConverter;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+
+import static io.snyk.jenkins.config.SnykConstants.SNYK_REPORT_HTML;
+import static io.snyk.jenkins.config.SnykConstants.SNYK_TEST_REPORT_JSON;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class SnykToHTML {
+  public static void generateReport(
+    Run<?, ?> build,
+    @Nonnull FilePath workspace,
+    Launcher launcher,
+    TaskListener log,
+    String reportExecutable,
+    String monitorUri
+  ) throws IOException, InterruptedException {
+    EnvVars env = build.getEnvironment(log);
+    ArgumentListBuilder args = new ArgumentListBuilder();
+
+    FilePath snykReportJson = workspace.child(SNYK_TEST_REPORT_JSON);
+    if (!snykReportJson.exists()) {
+      log.getLogger().println("Snyk report json doesn't exist");
+      return;
+    }
+
+    workspace.child(SNYK_REPORT_HTML).write("", UTF_8.name());
+
+    args.add(reportExecutable);
+    args.add("-i", SNYK_TEST_REPORT_JSON, "-o", SNYK_REPORT_HTML);
+    try {
+      int exitCode = launcher.launch()
+        .cmds(args)
+        .envs(env)
+        .quiet(true)
+        .pwd(workspace)
+        .join();
+      boolean success = exitCode == 0;
+      if (!success) {
+        log.getLogger().println("Generating Snyk html report was not successful");
+      }
+      String reportWithInlineCSS = workspace.child(SNYK_REPORT_HTML).readToString();
+      String modifiedHtmlReport = ReportConverter.getInstance().modifyHeadSection(reportWithInlineCSS);
+      String finalHtmlReport = ReportConverter.getInstance().injectMonitorLink(modifiedHtmlReport, monitorUri);
+      workspace.child(workspace.getName() + "_" + SNYK_REPORT_HTML).write(finalHtmlReport, UTF_8.name());
+    } catch (IOException ex) {
+      Util.displayIOException(ex, log);
+      ex.printStackTrace(log.fatalError("Snyk-to-Html command execution failed"));
+    }
+  }
+}

--- a/src/main/java/io/snyk/jenkins/transform/ReportConverter.java
+++ b/src/main/java/io/snyk/jenkins/transform/ReportConverter.java
@@ -3,6 +3,7 @@ package io.snyk.jenkins.transform;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Objects;
+import java.util.Optional;
 
 import jodd.jerry.Jerry;
 
@@ -35,11 +36,7 @@ public class ReportConverter {
     return document.html();
   }
 
-  public String injectMonitorLink(@Nonnull String html, @Nullable String monitorUri) {
-    if (monitorUri == null || monitorUri.isEmpty()) {
-      return html;
-    }
-
+  public String injectMonitorLink(@Nonnull String html, @Nonnull String monitorUri) {
     Jerry document = parser.parse(html);
     String monitorHtmlSnippet = format("<center><a target=\"_blank\" href=\"%s\">View On Snyk.io</a></center>", monitorUri);
     // prepend monitor link as first element after body

--- a/src/main/java/io/snyk/jenkins/workflow/SnykSecurityStep.java
+++ b/src/main/java/io/snyk/jenkins/workflow/SnykSecurityStep.java
@@ -10,6 +10,7 @@ import io.snyk.jenkins.Severity;
 import io.snyk.jenkins.SnykReportBuildAction;
 import io.snyk.jenkins.SnykStepBuilder;
 import io.snyk.jenkins.SnykStepBuilder.SnykStepBuilderDescriptor;
+import io.snyk.jenkins.SnykToHTML;
 import io.snyk.jenkins.credentials.SnykApiToken;
 import io.snyk.jenkins.exception.SnykErrorException;
 import io.snyk.jenkins.exception.SnykIssueException;
@@ -17,7 +18,6 @@ import io.snyk.jenkins.model.ObjectMapperHelper;
 import io.snyk.jenkins.model.SnykMonitorResult;
 import io.snyk.jenkins.model.SnykTestResult;
 import io.snyk.jenkins.tools.SnykInstallation;
-import io.snyk.jenkins.transform.ReportConverter;
 import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.workflow.steps.*;
@@ -41,7 +41,6 @@ import java.util.stream.Stream;
 import static com.cloudbees.plugins.credentials.CredentialsProvider.findCredentialById;
 import static hudson.Util.*;
 import static io.snyk.jenkins.config.SnykConstants.*;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class SnykSecurityStep extends Step {
 
@@ -235,12 +234,19 @@ public class SnykSecurityStep extends Step {
     }
 
     @SuppressWarnings("unused")
-    public FormValidation doCheckOrganisation(@QueryParameter String value, @QueryParameter String additionalArguments) {
+    public FormValidation doCheckOrganisation(
+      @QueryParameter String value,
+      @QueryParameter String additionalArguments
+    ) {
       return builderDescriptor.doCheckOrganisation(value, additionalArguments);
     }
 
     @SuppressWarnings("unused")
-    public FormValidation doCheckProjectName(@QueryParameter String value, @QueryParameter String monitorProjectOnBuild, @QueryParameter String additionalArguments) {
+    public FormValidation doCheckProjectName(
+      @QueryParameter String value,
+      @QueryParameter String monitorProjectOnBuild,
+      @QueryParameter String additionalArguments
+    ) {
       return builderDescriptor.doCheckProjectName(value, monitorProjectOnBuild, additionalArguments);
     }
   }
@@ -415,7 +421,14 @@ public class SnykSecurityStep extends Step {
           }
         }
 
-        generateSnykHtmlReport(build, workspace, launcher, log, installation.getReportExecutable(launcher), monitorUri);
+        SnykToHTML.generateReport(
+          build,
+          workspace,
+          launcher,
+          log,
+          installation.getReportExecutable(launcher),
+          monitorUri
+        );
 
         if (build.getActions(SnykReportBuildAction.class).isEmpty()) {
           build.addAction(new SnykReportBuildAction(build));
@@ -445,8 +458,8 @@ public class SnykSecurityStep extends Step {
     private SnykInstallation findSnykInstallation() {
       SnykStepBuilderDescriptor descriptor = Jenkins.get().getDescriptorByType(SnykStepBuilderDescriptor.class);
       return Stream.of(descriptor.getInstallations())
-                   .filter(installation -> installation.getName().equals(snykSecurityStep.snykInstallation))
-                   .findFirst().orElse(null);
+        .filter(installation -> installation.getName().equals(snykSecurityStep.snykInstallation))
+        .findFirst().orElse(null);
     }
 
     private SnykApiToken getSnykTokenCredential(Run<?, ?> run) {
@@ -477,41 +490,6 @@ public class SnykSecurityStep extends Step {
       }
 
       return args;
-    }
-
-    private void generateSnykHtmlReport(Run<?, ?> build, @Nonnull FilePath workspace, Launcher launcher, TaskListener log, String reportExecutable, String monitorUri) throws IOException, InterruptedException {
-      EnvVars env = build.getEnvironment(log);
-      ArgumentListBuilder args = new ArgumentListBuilder();
-
-      FilePath snykReportJson = workspace.child(SNYK_TEST_REPORT_JSON);
-      if (!snykReportJson.exists()) {
-        log.getLogger().println("Snyk report json doesn't exist");
-        return;
-      }
-
-      workspace.child(SNYK_REPORT_HTML).write("", UTF_8.name());
-
-      args.add(reportExecutable);
-      args.add("-i", SNYK_TEST_REPORT_JSON, "-o", SNYK_REPORT_HTML);
-      try {
-        int exitCode = launcher.launch()
-                               .cmds(args)
-                               .envs(env)
-                               .quiet(true)
-                               .pwd(workspace)
-                               .join();
-        boolean success = exitCode == 0;
-        if (!success) {
-          log.getLogger().println("Generating Snyk html report was not successful");
-        }
-        String reportWithInlineCSS = workspace.child(SNYK_REPORT_HTML).readToString();
-        String modifiedHtmlReport = ReportConverter.getInstance().modifyHeadSection(reportWithInlineCSS);
-        String finalHtmlReport = ReportConverter.getInstance().injectMonitorLink(modifiedHtmlReport, monitorUri);
-        workspace.child(workspace.getName() + "_" + SNYK_REPORT_HTML).write(finalHtmlReport, UTF_8.name());
-      } catch (IOException ex) {
-        Util.displayIOException(ex, log);
-        ex.printStackTrace(log.fatalError("Snyk-to-Html command execution failed"));
-      }
     }
   }
 }

--- a/src/test/java/io/snyk/jenkins/CLIArgsTest.java
+++ b/src/test/java/io/snyk/jenkins/CLIArgsTest.java
@@ -4,27 +4,24 @@ import hudson.EnvVars;
 import hudson.util.ArgumentListBuilder;
 import org.junit.Test;
 
+import static io.snyk.jenkins.CLIArgs.buildArgumentList;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
 
-public class SnykStepBuilderTest {
+public class CLIArgsTest {
 
   @Test
   public void buildArgumentList_shouldReturnSeverityThresholdLow_ifSeverityNotDefined() {
     EnvVars env = new EnvVars();
-    SnykStepBuilder snykStepBuilder = new SnykStepBuilder();
-
-    ArgumentListBuilder resolvedArguments = snykStepBuilder.buildArgumentList("/usr/bin/snyk", "test", env);
-
+    ArgumentListBuilder resolvedArguments = buildArgumentList("/usr/bin/snyk", "test", env);
     assertThat(resolvedArguments.toList(), hasItem("--severity-threshold=low"));
   }
 
   @Test
   public void buildArgumentList_shouldReturnSeverityThresholdCritical_ifCriticalIsDefined() {
     EnvVars env = new EnvVars();
-    SnykStepBuilder snykStepBuilder = new SnykStepBuilder();
     snykStepBuilder.setProjectName("my-project");
     snykStepBuilder.setSeverity("critical");
 
@@ -36,7 +33,6 @@ public class SnykStepBuilderTest {
   @Test
   public void buildArgumentList_shouldAppendConfigParametersAsSeparateArguments() {
     EnvVars env = new EnvVars();
-    SnykStepBuilder snykStepBuilder = new SnykStepBuilder();
     snykStepBuilder.setProjectName("my-project");
     snykStepBuilder.setSeverity("high");
 
@@ -55,7 +51,6 @@ public class SnykStepBuilderTest {
     EnvVars env = new EnvVars();
     env.put("BRANCH_NAME", "development");
     env.put("BUILD_NUMBER", "15");
-    SnykStepBuilder snykStepBuilder = new SnykStepBuilder();
     snykStepBuilder.setAdditionalArguments("--docker image:$BRANCH_NAME-${BUILD_NUMBER}");
 
     ArgumentListBuilder resolvedArguments = snykStepBuilder.buildArgumentList("/usr/bin/snyk", "test", env);
@@ -72,7 +67,6 @@ public class SnykStepBuilderTest {
   @Test
   public void buildArgumentList_shouldSplitAdditionalArgumentsWithAnyWhitespaceCharacter() {
     EnvVars env = new EnvVars();
-    SnykStepBuilder snykStepBuilder = new SnykStepBuilder();
     snykStepBuilder.setAdditionalArguments("--dev\n \n-d");
 
     ArgumentListBuilder resolvedArguments = snykStepBuilder.buildArgumentList("/usr/bin/snyk", "test", env);


### PR DESCRIPTION
WIP

Reducing duplication and differences across pipeline and freestyle steps so we can avoid repeating ourselves.

# To Do

The following will probably be done in separate PRs.

- [ ] Parse arguments once. Trim, convert to defaults/optionals.
  - This is difficult as there are multiple defaults in web form templates and step classes.
- [x] SnykToHTML duplication
  - #93
- [x] Snyk Test duplication
  - #93
- [x] Snyk Monitor duplication
  - #93
- [x] Result handling duplication (error, failure or success)
  - #93
- [x] Flow duplication (parse -> test -> monitor -> html -> result)
  - #93
- [x] Remove PATH workaround in SnykStepBuilder
  - #90 