### PR TITLE
feat: support multiple runs in a single build

### DIFF
--- a/src/main/java/io/snyk/jenkins/SnykReportBuildAction.java
+++ b/src/main/java/io/snyk/jenkins/SnykReportBuildAction.java
@@ -2,14 +2,23 @@ package io.snyk.jenkins;
 
 import hudson.model.Run;
 import jenkins.model.RunAction2;
+import org.kohsuke.stapler.Stapler;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class SnykReportBuildAction implements RunAction2 {
 
-  private Run<?, ?> run;
-  private String report;
+  private transient Run<?, ?> run;
+  private Map<String, String> reports;
 
-  public SnykReportBuildAction(String report) {
-    this.report = report;
+  public SnykReportBuildAction() {
+    this.reports = new HashMap<>();
   }
 
   @Override
@@ -43,7 +52,26 @@ public class SnykReportBuildAction implements RunAction2 {
   }
 
   @SuppressWarnings("unused")
-  public String getReport() {
-    return report;
+  public Map<String, String> getReports() {
+    return reports;
+  }
+
+  @SuppressWarnings("unused")
+  public Map<String, String> getReportLinks() {
+    return reports.keySet().stream().collect(Collectors.toMap(
+      key -> key,
+      key -> {
+        try {
+          return "./report?name=" + URLEncoder.encode(key, UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    ));
+  }
+
+  @SuppressWarnings("unused")
+  public String getCurrentReport() {
+    return reports.get(Stapler.getCurrentRequest().getParameter("name"));
   }
 }

--- a/src/main/java/io/snyk/jenkins/SnykTest.java
+++ b/src/main/java/io/snyk/jenkins/SnykTest.java
@@ -23,7 +23,7 @@ public class SnykTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(SnykTest.class);
 
-  public static String testProject(
+  public static Result testProject(
     SnykContext context,
     SnykConfig config,
     SnykInstallation installation,
@@ -85,6 +85,24 @@ public class SnykTest {
       );
     }
 
-    return reportJson;
+    return new Result(result.projectName, reportJson);
+  }
+
+  public static class Result {
+    private final String name;
+    private final String json;
+
+    public Result(String name, String json) {
+      this.name = name;
+      this.json = json;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public String getJson() {
+      return json;
+    }
   }
 }

--- a/src/main/java/io/snyk/jenkins/model/ObjectMapperHelper.java
+++ b/src/main/java/io/snyk/jenkins/model/ObjectMapperHelper.java
@@ -3,6 +3,7 @@ package io.snyk.jenkins.model;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
@@ -88,6 +89,9 @@ public class ObjectMapperHelper {
       } else if ("dependencyCount".equals(fieldName)) {
         parser.nextToken();
         snykTestResult.dependencyCount = parser.getIntValue();
+      } else if ("projectName".equals(fieldName)) {
+        parser.nextToken();
+        snykTestResult.projectName = parser.getText();
       } else {
         parser.skipChildren();
       }
@@ -107,6 +111,10 @@ public class ObjectMapperHelper {
       aggregatedTestResult.dependencyCount += entity.dependencyCount;
       aggregatedTestResult.uniqueCount += entity.uniqueCount;
     });
+
+    aggregatedTestResult.projectName = testResults.stream()
+      .map(result -> result.projectName)
+      .collect(Collectors.joining(", "));
 
     return aggregatedTestResult;
   }

--- a/src/main/java/io/snyk/jenkins/model/SnykTestResult.java
+++ b/src/main/java/io/snyk/jenkins/model/SnykTestResult.java
@@ -5,4 +5,5 @@ public class SnykTestResult {
   public String error;
   public int dependencyCount;
   public int uniqueCount;
+  public String projectName;
 }

--- a/src/main/resources/io/snyk/jenkins/SnykReportBuildAction/index.jelly
+++ b/src/main/resources/io/snyk/jenkins/SnykReportBuildAction/index.jelly
@@ -2,14 +2,16 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
   <l:layout title="Snyk Security Report" norefresh="true">
     <l:side-panel>
-      <st:include page="sidepanel.jelly" it="${it.run}" optional="true"/>
+      <st:include page="sidepanel.jelly" it="${it.getRun()}" optional="true"/>
     </l:side-panel>
     <l:main-panel>
       <h3>Reports</h3>
       <ul>
-        <li>
-          <a href="./report">View report</a>
-        </li>
+        <j:forEach var="link" items="${it.getReportLinks().entrySet()}">
+          <li>
+            <a href="${link.getValue()}">${link.getKey()}</a>
+          </li>
+        </j:forEach>
       </ul>
     </l:main-panel>
   </l:layout>

--- a/src/main/resources/io/snyk/jenkins/SnykReportBuildAction/report.jelly
+++ b/src/main/resources/io/snyk/jenkins/SnykReportBuildAction/report.jelly
@@ -2,16 +2,16 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
   <l:layout title="Snyk Security Report - Reports" norefresh="true">
     <l:side-panel>
-      <st:include page="sidepanel.jelly" it="${it.run}" optional="true"/>
+      <st:include page="sidepanel.jelly" it="${it.getRun()}" optional="true"/>
     </l:side-panel>
     <l:main-panel>
-      <a href="../${it.urlName}">Back To Reports</a>
+      <a href="../${it.getUrlName()}">Back To Reports</a>
       <br/>
       <br/>
-      <iframe width="95%" height="700" id="reportsframe" frameborder="0" srcdoc="${it.report}" />
+      <iframe width="95%" height="700" id="reportsframe" frameborder="0" srcdoc="${it.getCurrentReport()}" />
       <br/>
       <br/>
-      <a href="../${it.urlName}">Back To Reports</a>
+      <a href="../${it.getUrlName()}">Back To Reports</a>
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/src/main/resources/io/snyk/jenkins/SnykReportBuildAction/summary.jelly
+++ b/src/main/resources/io/snyk/jenkins/SnykReportBuildAction/summary.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default="true"?>
 <j:jelly xmlns:j="jelly:core" xmlns:t="/lib/hudson">
-  <t:summary icon="${it.getIconFileName}">
-    <a href="${it.urlName}">${it.displayName}</a>
+  <t:summary icon="${it.getIconFileName()}">
+    <a href="${it.getUrlName()}">${it.getDisplayName()}</a>
   </t:summary>
 </j:jelly>


### PR DESCRIPTION
This PR will build on #92

# To Do

- [x] Support multiple reports per build

## Identifying Reports

Since a step can be run with the same inputs, it's difficult to provide a human friendly input. I've gone with the best-case scenario for now where the project name (joined together with a comma for `--all-projects`) is used as the report identity.

Alternatively, we can use a random UUID or a timestamp as an ID and also have a human-friendly name.

## Memory

For massive reports, like #92, we may have memory issues again. An action with tons of reports can get big. But it's hard to know how common this issue will be to optimise for it.