### PR TITLE
feat: support multiple reports in a single build

### DIFF
--- a/src/main/java/io/snyk/jenkins/SnykToHTML.java
+++ b/src/main/java/io/snyk/jenkins/SnykToHTML.java
@@ -3,61 +3,68 @@ package io.snyk.jenkins;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.Util;
-import hudson.model.TaskListener;
 import hudson.util.ArgumentListBuilder;
 import io.snyk.jenkins.tools.SnykInstallation;
 import io.snyk.jenkins.transform.ReportConverter;
 import jenkins.model.Jenkins;
 
 import java.io.IOException;
+import java.time.Instant;
 
 import static io.snyk.jenkins.config.SnykConstants.SNYK_REPORT_HTML;
 import static io.snyk.jenkins.config.SnykConstants.SNYK_TEST_REPORT_JSON;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class SnykToHTML {
-  public static void generateReport(
+  public static FilePath generateReport(
     SnykContext context,
     SnykInstallation installation
-  ) throws IOException, InterruptedException {
-    TaskListener log = context.getTaskListener();
-    FilePath workspace = context.getWorkspace();
-    Launcher launcher = context.getLauncher();
-    EnvVars env = context.getEnvVars();
-
-    ArgumentListBuilder args = new ArgumentListBuilder();
-
-    FilePath snykReportJson = workspace.child(SNYK_TEST_REPORT_JSON);
-    if (!snykReportJson.exists()) {
-      log.getLogger().println("Snyk report json doesn't exist");
-      return;
-    }
-
-    workspace.child(SNYK_REPORT_HTML).write("", UTF_8.name());
-
-    args.add(installation.getReportExecutable(launcher));
-    args.add("-i", SNYK_TEST_REPORT_JSON, "-o", SNYK_REPORT_HTML);
+  ) {
     try {
+      FilePath workspace = context.getWorkspace();
+      Launcher launcher = context.getLauncher();
+      EnvVars env = context.getEnvVars();
+
+      FilePath snykReportJson = workspace.child(SNYK_TEST_REPORT_JSON);
+      if (!snykReportJson.exists()) {
+        throw new RuntimeException("Snyk Report JSON does not exist.");
+      }
+
+      FilePath reportPath = workspace.child(getURLSafeDateTime() + "_" + SNYK_REPORT_HTML);
+      reportPath.write("", UTF_8.name());
+
+      ArgumentListBuilder args = new ArgumentListBuilder()
+        .add(installation.getReportExecutable(launcher))
+        .add("-i", SNYK_TEST_REPORT_JSON);
+
       int exitCode = launcher.launch()
         .cmds(args)
         .envs(env)
+        .stdout(reportPath.write())
         .quiet(true)
         .pwd(workspace)
         .join();
-      boolean success = exitCode == 0;
-      if (!success) {
-        log.getLogger().println("Generating Snyk html report was not successful");
+
+      if (exitCode != 0) {
+        throw new RuntimeException("Exited with non-zero exit code. (Exit Code: " + exitCode + ")");
       }
-      String reportWithInlineCSS = workspace.child(SNYK_REPORT_HTML).readToString();
-      String finalHtmlReport = ReportConverter.getInstance().modifyHeadSection(
-        reportWithInlineCSS,
+
+      String reportContents = ReportConverter.getInstance().modifyHeadSection(
+        reportPath.readToString(),
         Jenkins.get().servletContext.getContextPath()
       );
-      workspace.child(workspace.getName() + "_" + SNYK_REPORT_HTML).write(finalHtmlReport, UTF_8.name());
-    } catch (IOException ex) {
-      Util.displayIOException(ex, log);
-      ex.printStackTrace(log.fatalError("Snyk-to-Html command execution failed"));
+
+      reportPath.write(reportContents, UTF_8.name());
+
+      return reportPath;
+    } catch (IOException | InterruptedException | RuntimeException ex) {
+      throw new RuntimeException("Failed to generate report.", ex);
     }
+  }
+
+  private static String getURLSafeDateTime() {
+    return Instant.now().toString()
+      .replaceAll(":", "-")
+      .replaceAll("\\.", "-");
   }
 }


### PR DESCRIPTION
As #91 and #92 is using a new approach, it'll need more thorough testing.

To get this feature out, we can easily support multiple reports by replacing the `workspace.getName()` in the Report filename with the current date/time. This way, reports will have a unique name for each scan.

I kept the date/time at the start of the name as we already have logic to list all artifacts ending with `snyk_report.html` in our sidebar link so no changes need to be made there and we'll be completely backwards compatible without additional work.

![Screenshot 2021-07-12 at 19 30 51](https://user-images.githubusercontent.com/79453381/125338853-9f053080-e348-11eb-8edf-3c6e3cebbb15.png)
