### PR TITLE
feat: provide integration name and version to cli

### DIFF
--- a/src/main/java/io/snyk/jenkins/PluginMetadata.java
+++ b/src/main/java/io/snyk/jenkins/PluginMetadata.java
@@ -1,0 +1,27 @@
+package io.snyk.jenkins;
+
+import hudson.Plugin;
+import hudson.PluginWrapper;
+import jenkins.model.Jenkins;
+
+import java.util.Optional;
+
+public class PluginMetadata {
+
+  private static final String INTEGRATION_NAME = "JENKINS";
+  private static String INTEGRATION_VERSION;
+
+  public static String getIntegrationName() {
+    return INTEGRATION_NAME;
+  }
+
+  public static String getIntegrationVersion() {
+    if (INTEGRATION_VERSION == null) {
+      INTEGRATION_VERSION = Optional.ofNullable(Jenkins.get().getPlugin("snyk-security-scanner"))
+        .map(Plugin::getWrapper)
+        .map(PluginWrapper::getVersion)
+        .orElse("unknown");
+    }
+    return INTEGRATION_VERSION;
+  }
+}

--- a/src/main/java/io/snyk/jenkins/SnykMonitor.java
+++ b/src/main/java/io/snyk/jenkins/SnykMonitor.java
@@ -11,13 +11,15 @@ import io.snyk.jenkins.tools.SnykInstallation;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.Map;
 
 public class SnykMonitor {
 
   public static void monitorProject(
     SnykContext context,
     SnykConfig config,
-    SnykInstallation installation
+    SnykInstallation installation,
+    String snykToken
   ) throws IOException, InterruptedException {
     PrintStream logger = context.getLogger();
     FilePath workspace = context.getWorkspace();
@@ -31,11 +33,13 @@ public class SnykMonitor {
       envVars
     );
 
+    Map<String, String> commandEnvVars = CommandLine.asEnvVars(snykToken, envVars);
+
     logger.println("Monitoring project...");
     logger.println("> " + command);
     int exitCode = launcher.launch()
         .cmds(command)
-        .envs(envVars)
+        .envs(commandEnvVars)
         .stdout(logger)
         .stderr(logger)
         .quiet(true)

--- a/src/main/java/io/snyk/jenkins/SnykStepFlow.java
+++ b/src/main/java/io/snyk/jenkins/SnykStepFlow.java
@@ -31,12 +31,12 @@ public class SnykStepFlow {
         config.getSnykInstallation()
       );
 
-      context.getEnvVars().put("SNYK_TOKEN", SnykApiToken.getToken(context, config.getSnykTokenId()));
+      String snykToken = SnykApiToken.getToken(context, config.getSnykTokenId());
 
-      foundIssues = SnykStepFlow.testProject(context, config, installation);
+      foundIssues = SnykStepFlow.testProject(context, config, installation, snykToken);
 
       if (config.isMonitorProjectOnBuild()) {
-        SnykMonitor.monitorProject(context, config, installation);
+        SnykMonitor.monitorProject(context, config, installation, snykToken);
       }
     } catch (IOException | InterruptedException | RuntimeException ex) {
       if (context != null) {
@@ -57,9 +57,9 @@ public class SnykStepFlow {
     }
   }
 
-  private static boolean testProject(SnykContext context, SnykConfig config, SnykInstallation installation)
+  private static boolean testProject(SnykContext context, SnykConfig config, SnykInstallation installation, String snykToken)
   throws IOException, InterruptedException {
-    SnykTest.Result testResult = SnykTest.testProject(context, config, installation);
+    SnykTest.Result testResult = SnykTest.testProject(context, config, installation, snykToken);
     FilePath report = SnykToHTML.generateReport(context, installation, testResult.testJsonPath);
     archiveReport(context, report);
     addSidebarLink(context);

--- a/src/main/java/io/snyk/jenkins/SnykTest.java
+++ b/src/main/java/io/snyk/jenkins/SnykTest.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.util.Map;
 
 import static hudson.Util.fixEmptyAndTrim;
 import static io.snyk.jenkins.Utils.getURLSafeDateTime;
@@ -27,7 +28,8 @@ public class SnykTest {
   public static Result testProject(
     SnykContext context,
     SnykConfig config,
-    SnykInstallation installation
+    SnykInstallation installation,
+    String snykToken
   ) throws IOException, InterruptedException {
     PrintStream logger = context.getLogger();
     FilePath workspace = context.getWorkspace();
@@ -45,13 +47,15 @@ public class SnykTest {
       )
       .add("--json");
 
+    Map<String, String> commandEnvVars = CommandLine.asEnvVars(snykToken, envVars);
+
     int exitCode;
     try (OutputStream stdoutWriter = stdoutPath.write()) {
       logger.println("Testing project...");
       logger.println("> " + command);
       exitCode = launcher.launch()
         .cmds(command)
-        .envs(envVars)
+        .envs(commandEnvVars)
         .stdout(stdoutWriter)
         .stderr(logger)
         .quiet(true)

--- a/src/main/java/io/snyk/jenkins/SnykToHTML.java
+++ b/src/main/java/io/snyk/jenkins/SnykToHTML.java
@@ -4,6 +4,7 @@ import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.util.ArgumentListBuilder;
+import io.snyk.jenkins.command.CommandLine;
 import io.snyk.jenkins.tools.SnykInstallation;
 import io.snyk.jenkins.transform.ReportConverter;
 import jenkins.model.Jenkins;
@@ -13,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.util.Map;
 
 import static io.snyk.jenkins.Utils.getURLSafeDateTime;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -42,13 +44,15 @@ public class SnykToHTML {
         .add(installation.getReportExecutable(launcher))
         .add("-i", testJsonPath.getRemote());
 
+      Map<String, String> commandEnvVars = CommandLine.asEnvVars(env);
+
       int exitCode;
       try (OutputStream reportWriter = stdoutPath.write()) {
         logger.println("Generating report...");
         logger.println("> " + command);
         exitCode = launcher.launch()
           .cmds(command)
-          .envs(env)
+          .envs(commandEnvVars)
           .stdout(reportWriter)
           .stderr(logger)
           .quiet(true)

--- a/src/main/java/io/snyk/jenkins/command/CommandLine.java
+++ b/src/main/java/io/snyk/jenkins/command/CommandLine.java
@@ -3,6 +3,7 @@ package io.snyk.jenkins.command;
 import hudson.EnvVars;
 import hudson.Util;
 import hudson.util.ArgumentListBuilder;
+import io.snyk.jenkins.PluginMetadata;
 import io.snyk.jenkins.config.SnykConfig;
 
 import java.util.Arrays;
@@ -48,10 +49,11 @@ public class CommandLine {
   }
 
   public static Map<String, String> asEnvVars(String snykToken, EnvVars envVars) {
-    return new HashMap<String, String>() {{
-      putAll(envVars);
-      Optional.ofNullable(snykToken).ifPresent(token -> put("SNYK_TOKEN", token));
-    }};
+    HashMap<String, String> result = new HashMap<>(envVars);
+    Optional.ofNullable(snykToken).ifPresent(token -> result.put("SNYK_TOKEN", token));
+    result.put("SNYK_INTEGRATION_NAME", PluginMetadata.getIntegrationName());
+    result.put("SNYK_INTEGRATION_VERSION", PluginMetadata.getIntegrationVersion());
+    return result;
   }
 
   public static Map<String, String> asEnvVars(EnvVars envVars) {

--- a/src/main/java/io/snyk/jenkins/command/CommandLine.java
+++ b/src/main/java/io/snyk/jenkins/command/CommandLine.java
@@ -6,6 +6,8 @@ import hudson.util.ArgumentListBuilder;
 import io.snyk.jenkins.config.SnykConfig;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -43,5 +45,16 @@ public class CommandLine {
         .forEach(args::add));
 
     return args;
+  }
+
+  public static Map<String, String> asEnvVars(String snykToken, EnvVars envVars) {
+    return new HashMap<String, String>() {{
+      putAll(envVars);
+      Optional.ofNullable(snykToken).ifPresent(token -> put("SNYK_TOKEN", token));
+    }};
+  }
+
+  public static Map<String, String> asEnvVars(EnvVars envVars) {
+    return asEnvVars(null, envVars);
   }
 }


### PR DESCRIPTION
We currently cannot detect where users are executing from in CLI. Added these env vars will provide that information.

I've also removed `SNYK_TOKEN` from the global `EnvVars` as it can leak credentials. Each process now takes a copy of it with additional variables.