### PR TITLE
fix: lower minimum required credentials plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,12 +44,12 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>symbol-annotation</artifactId>
-      <version>1.23</version>
+      <version>1.22</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.5</version>
+      <version>2.3.19</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
Improves compatibility with existing installations. Less things for people to upgrade to use this plugin.

We bumped this due to vulnerabilities, but it doesn't need to be so high.

https://snyk.io/vuln/SNYK-JAVA-ORGJENKINSCIPLUGINS-1292149