### PR TITLE
feat: support token provided in an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ pipeline {
         echo 'Testing...'
         snykSecurity(
           snykInstallation: '<Your Snyk Installation Name>',
-          snykTokenId: '<Your Snyk Token ID>',
+          snykTokenId: '<Your Snyk API Token ID>',
           // place other parameters here
         )
       }
@@ -152,15 +152,18 @@ You can pass the following parameters to your `snykSecurity` step.
 
 Snyk Installation Name. As configured in "[2. Configure a Snyk Installation](#2-configure-a-snyk-installation)".
 
-#### `snykTokenId` (required)
+#### `snykTokenId` (optional, default: *none*)
 
 Snyk API Token Credential ID. As configured in "[3. Configure a Snyk API Token Credential](#3-configure-a-snyk-api-token-credential)".
 
-#### `failOnIssues` (optional, default `true`)
+If you prefer to provide the Snyk API Token another way, such using alternative credential bindings, you'll need to
+provide a "SNYK_TOKEN" build environment variable.
+
+#### `failOnIssues` (optional, default: `true`)
 
 Whether the step should fail if issues and vulnerabilities are found.
 
-#### `failOnError` (optional, default `true`)
+#### `failOnError` (optional, default: `true`)
 
 Whether the step should fail if Snyk fails to scan the project due to an error. Errors include scenarios like: failing
 to download Snyk's binaries, improper Jenkins setup, bad configuration and server errors.

--- a/src/main/java/io/snyk/jenkins/SnykStepBuilder.java
+++ b/src/main/java/io/snyk/jenkins/SnykStepBuilder.java
@@ -264,7 +264,7 @@ public class SnykStepBuilder extends Builder implements SimpleBuildStep, SnykCon
         }
       }
       if (fixEmptyAndTrim(value) == null) {
-        return FormValidation.error("Snyk API token is required.");
+        return FormValidation.warningWithMarkup("A Snyk API token is required. If you do not provide credentials, make sure to provide a <code>SNYK_TOKEN</code> build environment variable.");
       }
 
       if (null == CredentialsMatchers.firstOrNull(lookupCredentials(SnykApiToken.class, Jenkins.get(), ACL.SYSTEM, Collections.emptyList()),

--- a/src/main/java/io/snyk/jenkins/command/CommandLine.java
+++ b/src/main/java/io/snyk/jenkins/command/CommandLine.java
@@ -12,6 +12,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
+import static io.snyk.jenkins.credentials.SnykApiToken.SNYK_TOKEN_ENV_KEY;
+
 public class CommandLine {
   public static ArgumentListBuilder asArgumentList(String executablePath, Command command, SnykConfig config, EnvVars env) {
     Function<String, String> replaceMacroWithEnv = str -> Util.replaceMacro(str, env);
@@ -50,7 +52,7 @@ public class CommandLine {
 
   public static Map<String, String> asEnvVars(String snykToken, EnvVars envVars) {
     HashMap<String, String> result = new HashMap<>(envVars);
-    Optional.ofNullable(snykToken).ifPresent(token -> result.put("SNYK_TOKEN", token));
+    Optional.ofNullable(snykToken).ifPresent(token -> result.put(SNYK_TOKEN_ENV_KEY, token));
     result.put("SNYK_INTEGRATION_NAME", PluginMetadata.getIntegrationName());
     result.put("SNYK_INTEGRATION_VERSION", PluginMetadata.getIntegrationVersion());
     return result;

--- a/src/main/java/io/snyk/jenkins/credentials/SnykApiToken.java
+++ b/src/main/java/io/snyk/jenkins/credentials/SnykApiToken.java
@@ -31,10 +31,18 @@ public interface SnykApiToken extends StandardCredentials {
     }
   }
 
+  String SNYK_TOKEN_ENV_KEY = "SNYK_TOKEN";
+
   static String getToken(SnykContext context, String snykTokenId) {
-    return Optional.ofNullable(findCredentialById(snykTokenId, SnykApiToken.class, context.getRun()))
-      .orElseThrow(() -> new RuntimeException("Snyk API token with ID '" + snykTokenId + "' was not found. Please configure the build properly and retry."))
-      .getToken()
-      .getPlainText();
+    return Optional.ofNullable(snykTokenId)
+      .map(Util::fixEmptyAndTrim)
+      .map(id -> Optional.ofNullable(findCredentialById(id, SnykApiToken.class, context.getRun()))
+        .orElseThrow(() -> new RuntimeException("Snyk API token with Credential ID '" + snykTokenId + "' was not found.")))
+      .map(SnykApiToken::getToken)
+      .map(Secret::getPlainText)
+      .map(Util::fixEmptyAndTrim)
+      .map(Optional::of)
+      .orElseGet(() -> Optional.ofNullable(context.getEnvVars().get(SNYK_TOKEN_ENV_KEY)))
+      .orElseThrow(() -> new RuntimeException("Snyk API token not provided. Please assign your credentials to 'snykTokenId' in your build configuration or assign the token to a 'SNYK_TOKEN' build environment variable"));
   }
 }

--- a/src/main/resources/io/snyk/jenkins/SnykStepBuilder/config.jelly
+++ b/src/main/resources/io/snyk/jenkins/SnykStepBuilder/config.jelly
@@ -33,7 +33,7 @@
 
   <!-- common configuration -->
   <f:section title="">
-    <f:entry title="Snyk token" field="snykTokenId">
+    <f:entry title="Snyk API token" field="snykTokenId">
       <c:select/>
     </f:entry>
     <f:entry title="Target file" field="targetFile">

--- a/src/main/resources/io/snyk/jenkins/SnykStepBuilder/help-snykTokenId.html
+++ b/src/main/resources/io/snyk/jenkins/SnykStepBuilder/help-snykTokenId.html
@@ -1,3 +1,10 @@
 <div>
-  <p>The ID for the API token from the Credentials plugin to be used to authenticate to Snyk. The type of the credential must be "Snyk API token"</p>
+  <p>
+    This needs to be the ID of an existing "Snyk API Token" credential. The token will be used to authenticate with
+    Snyk.
+  </p>
+  <p>
+    If you prefer to provide the Snyk API Token another way, such using alternative credential bindings, you'll need to
+    provide a <code>SNYK_TOKEN</code> build environment variable.
+  </p>
 </div>

--- a/src/test/java/io/snyk/jenkins/SnykStepBuilderDescriptorTest.java
+++ b/src/test/java/io/snyk/jenkins/SnykStepBuilderDescriptorTest.java
@@ -66,11 +66,11 @@ public class SnykStepBuilderDescriptorTest {
   }
 
   @Test
-  public void doCheckSnykTokenId_shouldReturnError_ifSnykTokenIsEmpty() throws Exception {
+  public void doCheckSnykTokenId_shouldReturnWarning_ifSnykTokenIsEmpty() throws Exception {
     jenkins.createFreeStyleProject();
     Kind snykTokenIdValidation = instance.doCheckSnykTokenId(jenkins.getInstance().getItems().get(0),null).kind;
 
-    assertThat(snykTokenIdValidation, is(Kind.ERROR));
+    assertThat(snykTokenIdValidation, is(Kind.WARNING));
   }
 
   @Test


### PR DESCRIPTION
In v1 we used to support `SNYK_TOKEN` in the build environment. In v2 we replaced this with a custom credential type assigned with `snykTokenId`.

It's worth supporting both as users may want to provide the token in some other way, such as a Hashicorp Vault credential. We can prefer `snykTokenId`, and if it's not set, fallback to `SNYK_TOKEN` and then fail if neither is set.

Jenkins supports arbritrary inputs using Credential Bindings in both Freestyle and Pipeline projects.

In the example below, I stored a token as a "Secret text" type (rather than "Snyk API token") and in the build, I've assigned it to a SNYK_TOKEN variable. This gets passed through to the build agent as an environment variable (`EnvVars`).

![Screenshot 2021-07-19 at 12 43 31](https://user-images.githubusercontent.com/79453381/126155035-a36b1dba-138d-416f-b39f-048dcd84d252.png)

Fixes #73 
