### PR TITLE
fix: do not add json flag to end as it conflicts with `--` flags

### DIFF
--- a/src/main/java/io/snyk/jenkins/SnykTest.java
+++ b/src/main/java/io/snyk/jenkins/SnykTest.java
@@ -44,8 +44,7 @@ public class SnykTest {
         Command.TEST,
         config,
         envVars
-      )
-      .add("--json");
+      );
 
     Map<String, String> commandEnvVars = CommandLine.asEnvVars(snykToken, envVars);
 

--- a/src/main/java/io/snyk/jenkins/command/CommandLine.java
+++ b/src/main/java/io/snyk/jenkins/command/CommandLine.java
@@ -19,6 +19,10 @@ public class CommandLine {
     Function<String, String> replaceMacroWithEnv = str -> Util.replaceMacro(str, env);
     ArgumentListBuilder args = new ArgumentListBuilder(executablePath, command.commandName());
 
+    if (command == Command.TEST) {
+      args.add("--json");
+    }
+
     Optional.ofNullable(config.getSeverity())
       .map(Util::fixEmptyAndTrim)
       .map(replaceMacroWithEnv)

--- a/src/test/java/io/snyk/jenkins/command/CommandLineTest.java
+++ b/src/test/java/io/snyk/jenkins/command/CommandLineTest.java
@@ -19,9 +19,19 @@ public class CommandLineTest {
     EnvVars env = new EnvVars();
     SnykConfig config = Mockito.mock(SnykConfig.class);
 
+    ArgumentListBuilder result = CommandLine.asArgumentList("/usr/bin/snyk", Command.MONITOR, config, env);
+
+    assertThat(result.toList(), equalTo(asList("/usr/bin/snyk", "monitor")));
+  }
+
+  @Test
+  public void shouldIncludeJsonForTest() {
+    EnvVars env = new EnvVars();
+    SnykConfig config = Mockito.mock(SnykConfig.class);
+
     ArgumentListBuilder result = CommandLine.asArgumentList("/usr/bin/snyk", Command.TEST, config, env);
 
-    assertThat(result.toList(), equalTo(asList("/usr/bin/snyk", "test")));
+    assertThat(result.toList(), equalTo(asList("/usr/bin/snyk", "test", "--json")));
   }
 
   @Test
@@ -49,6 +59,7 @@ public class CommandLineTest {
     assertThat(result.toList(), equalTo(asList(
       "/usr/bin/snyk",
       "test",
+      "--json",
       "--severity-threshold=high",
       "--project-name=my-project"
     )));
@@ -69,19 +80,22 @@ public class CommandLineTest {
   }
 
   @Test
-  public void shouldIncludeAdditionalArguments() {
+  public void shouldAppendAdditionalArgumentsToTheEnd() {
     EnvVars env = new EnvVars();
 
     SnykConfig config = Mockito.mock(SnykConfig.class);
-    when(config.getAdditionalArguments()).thenReturn("--dev\n \n-d");
+    when(config.getAdditionalArguments()).thenReturn("--dev\n \n-d -- --settings=settings.xml");
 
     ArgumentListBuilder result = CommandLine.asArgumentList("/usr/bin/snyk", Command.TEST, config, env);
 
     assertThat(result.toList(), equalTo(asList(
       "/usr/bin/snyk",
       "test",
+      "--json",
       "--dev",
-      "-d"
+      "-d",
+      "--",
+      "--settings=settings.xml"
     )));
   }
 }


### PR DESCRIPTION
'--' is used to pass args to Maven, Gradle, etc. and may be used in "additionalArgs". So appending `--json` will send it
to Maven rather than Snyk CLI and cause an error.

Fixes #103 