### PR TITLE
fix: installation home is nullable by convention

### DIFF
--- a/src/main/java/io/snyk/jenkins/tools/SnykInstallation.java
+++ b/src/main/java/io/snyk/jenkins/tools/SnykInstallation.java
@@ -20,6 +20,7 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -31,7 +32,7 @@ import java.util.stream.Stream;
 public class SnykInstallation extends ToolInstallation implements EnvironmentSpecific<SnykInstallation>, NodeSpecific<SnykInstallation> {
 
   @DataBoundConstructor
-  public SnykInstallation(@Nonnull String name, @Nonnull String home, List<? extends ToolProperty<?>> properties) {
+  public SnykInstallation(@Nonnull String name, @Nullable String home, List<? extends ToolProperty<?>> properties) {
     super(name, home, properties);
   }
 


### PR DESCRIPTION
Installation `home` is nullable by convention. For example:
- `getHome` under `ToolInstallation` is assigned `@CheckForNull` by Jenkins. So even with `@Nonnull` on our subclass, it doesn't do much as the getter assumes it's nullable.
- CasC will fail as it assumes `home` can be null so doesn't serialise a default for it. So when it sees `@Nonnull` we get an error during deserialisation. (See #105)

I figured this out by searching for the error in other plugins. Seems to be a common issue. For example:

- https://issues.jenkins.io/browse/JENKINS-57508
- https://github.com/jenkinsci/nodejs-plugin/commit/b3bb9302ac7cbb07e7e6da1efba6dbe57ad1df88

All of our current usages of `home` handle the nullable nature of it already as `home` is private and `getHome` has `@CheckForNull`.

Fixes #105