### PR TITLE
fix: improve build node platform detection

### DIFF
--- a/src/main/java/io/snyk/jenkins/tools/Platform.java
+++ b/src/main/java/io/snyk/jenkins/tools/Platform.java
@@ -1,7 +1,6 @@
 package io.snyk.jenkins.tools;
 
 import javax.annotation.Nonnull;
-import java.nio.file.Paths;
 import java.util.Locale;
 import java.util.Map;
 
@@ -29,14 +28,20 @@ public enum Platform {
 
   @Nonnull
   private static Platform detect(@Nonnull Map<Object, Object> systemProperties) {
-    String arch = ((String) systemProperties.get("os.name")).toLowerCase(Locale.ENGLISH);
-    if (arch.contains("linux")) {
-      return Paths.get("/etc/alpine-release").toFile().exists() ? LINUX_ALPINE : LINUX;
-    } else if (arch.contains("mac os x") || arch.contains("darwin") || arch.contains("osx")) {
+    String osName = ((String) systemProperties.get("os.name")).toLowerCase(Locale.ENGLISH);
+    String osArch = ((String) systemProperties.get("os.arch")).toLowerCase(Locale.ENGLISH);
+    if (osName.contains("linux")) {
+      // detect whether we run on linux alpine
+      if (osArch.contains("amd64") || osArch.contains("86_64")) {
+        return LINUX;
+      } else {
+        return LINUX_ALPINE;
+      }
+    } else if (osName.contains("mac os x") || osName.contains("darwin") || osName.contains("osx")) {
       return MAC_OS;
-    } else if (arch.contains("windows")) {
+    } else if (osName.contains("windows")) {
       return WINDOWS;
     }
-    throw new RuntimeException("Unsupported platform. (OS: " + arch + ")");
+    throw new RuntimeException("Unsupported platform. (OS: " + osName + ", Arch: " + osArch + ")");
   }
 }

--- a/src/main/java/io/snyk/jenkins/tools/SnykInstaller.java
+++ b/src/main/java/io/snyk/jenkins/tools/SnykInstaller.java
@@ -94,6 +94,9 @@ public class SnykInstaller extends ToolInstaller {
       }
 
       Platform platform = nodeChannel.call(new GetPlatform());
+      if (LOG.isTraceEnabled()) {
+        LOG.trace("Detected Build Node platform: {}", platform);
+      }
       URL snykDownloadUrl = DownloadService.getDownloadUrlForSnyk(version, platform);
       URL snykToHtmlDownloadUrl = DownloadService.getDownloadUrlForSnykToHtml("latest", platform);
       expected.mkdirs();


### PR DESCRIPTION
This PR improves platform detection on build nodes.
Instead of checking for file presence of `/etc/alpine-release` file, we use java property `os.arch` to detect whether we are running on amd64 or arm architecture.

This fix should fix platform detection in Docker-in-Docker setups (or for on-demand agents with Kubernetes setup).