### PR TITLE
fix: bump min jenkins version to match min version in some dependencies [ROAD-1060]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,6 @@
 buildPlugin(configurations: [
   [ platform: "linux", jdk: "8" ],
   [ platform: "windows", jdk: "8" ],
-  [ platform: "linux", jdk: "8", jenkins: "2.222.4", javaLabel: 8 ],
-  [ platform: "windows", jdk: "8", jenkins: "2.222.4", javaLabel: 8 ]
+  [ platform: "linux", jdk: "8", jenkins: "2.289.3", javaLabel: 8 ],
+  [ platform: "windows", jdk: "8", jenkins: "2.289.3", javaLabel: 8 ]
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,6 @@
 buildPlugin(configurations: [
   [ platform: "linux", jdk: "8" ],
   [ platform: "windows", jdk: "8" ],
-  [ platform: "linux", jdk: "8", jenkins: "2.290", javaLabel: 8 ],
-  [ platform: "windows", jdk: "8", jenkins: "2.290", javaLabel: 8 ]
+  [ platform: "linux", jdk: "8", jenkins: "2.289.3", javaLabel: 8 ],
+  [ platform: "windows", jdk: "8", jenkins: "2.289.3", javaLabel: 8 ]
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,6 @@
 buildPlugin(configurations: [
   [ platform: "linux", jdk: "8" ],
   [ platform: "windows", jdk: "8" ],
-  [ platform: "linux", jdk: "8", jenkins: "2.289.3", javaLabel: 8 ],
-  [ platform: "windows", jdk: "8", jenkins: "2.289.3", javaLabel: 8 ]
+  [ platform: "linux", jdk: "8", jenkins: "2.290", javaLabel: 8 ],
+  [ platform: "windows", jdk: "8", jenkins: "2.290", javaLabel: 8 ]
 ])

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) [2022] [Snyk Ltd]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,41 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+ADDITIONAL INFORMATION ABOUT LICENSING
+
+Certain files distributed by Snyk Ltd and/or its affiliates are
+subject to the following clarification and special exception to the GPLv2,
+based on the GNU Project exception for its Classpath libraries, known as the
+GNU Classpath Exception.
+
+Note that Snyk includes multiple, independent programs in this software
+package.  Some of those programs are provided under licenses deemed
+incompatible with the GPLv2 by the Free Software Foundation and others.
+For example, the package includes programs licensed under the Apache
+License, Version 2.0 and may include FreeType. Such programs are licensed
+to you under their original licenses.
+
+Snyk facilitates your further distribution of this package by adding the
+Classpath Exception to the necessary parts of its GPLv2 code, which permits
+you to use that code in combination with other independent modules not
+licensed under the GPLv2. However, note that this would not permit you to
+commingle code under an incompatible license with Snyk's GPLv2 licensed
+code by, for example, cutting and pasting such code into a file also
+containing Snyk's GPLv2 licensed code and then distributing the result.
+
+Additionally, if you were to remove the Classpath Exception from any of the
+files to which it applies and distribute the result, you would likely be
+required to license some or all of the other code in that distribution under
+the GPLv2 as well, and since the GPLv2 is incompatible with the license terms
+of some items included in the distribution by Snyk, removing the Classpath
+Exception could therefore effectively compromise your ability to further
+distribute the package.
+
+Failing to distribute notices associated with some files may also create
+unexpected legal consequences.
+
+Proceed with caution and we recommend that you obtain the advice of a lawyer
+skilled in open source matters before removing the Classpath Exception or
+making modifications to this package which may subsequently be redistributed
+and/or involve the use of third party software.

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.thoughtworks.xstream</groupId>
+      <artifactId>xstream</artifactId>
+      <version>1.4.18</version>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>2.12.6.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   </licenses>
 
   <properties>
-    <jenkins.version>2.290</jenkins.version>
+    <jenkins.version>2.289.3</jenkins.version>
     <java.level>8</java.level>
     <configuration-as-code.version>1.51</configuration-as-code.version>
     <surefire.rerunFailingTestsCount>0</surefire.rerunFailingTestsCount>
@@ -38,49 +38,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.thoughtworks.xstream</groupId>
-      <artifactId>xstream</artifactId>
-      <version>1.4.19</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-core</artifactId>
-      <version>5.3.22</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-beans</artifactId>
-      <version>5.3.22</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-crypto</artifactId>
-      <version>5.7.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-core</artifactId>
-      <version>5.7.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-web</artifactId>
-      <version>5.7.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-web</artifactId>
-      <version>5.3.22</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-expression</artifactId>
-      <version>5.3.22</version>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.6.1</version>
+      <version>2.13.3</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   </licenses>
 
   <properties>
-    <jenkins.version>2.289.3</jenkins.version>
+    <jenkins.version>2.290</jenkins.version>
     <java.level>8</java.level>
     <configuration-as-code.version>1.51</configuration-as-code.version>
     <surefire.rerunFailingTestsCount>0</surefire.rerunFailingTestsCount>
@@ -41,6 +41,41 @@
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
       <version>1.4.19</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>5.3.22</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+      <version>5.3.22</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-crypto</artifactId>
+      <version>5.7.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-core</artifactId>
+      <version>5.7.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-web</artifactId>
+      <version>5.7.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <version>5.3.22</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-expression</artifactId>
+      <version>5.3.22</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.4.18</version>
+      <version>1.4.19</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   </licenses>
 
   <properties>
-    <jenkins.version>2.289.1</jenkins.version>
+    <jenkins.version>2.289.3</jenkins.version>
     <java.level>8</java.level>
     <configuration-as-code.version>1.51</configuration-as-code.version>
     <surefire.rerunFailingTestsCount>0</surefire.rerunFailingTestsCount>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   </licenses>
 
   <properties>
-    <jenkins.version>2.222.4</jenkins.version>
+    <jenkins.version>2.289.1</jenkins.version>
     <java.level>8</java.level>
     <configuration-as-code.version>1.51</configuration-as-code.version>
     <surefire.rerunFailingTestsCount>0</surefire.rerunFailingTestsCount>


### PR DESCRIPTION
Jenkins will give a warning that this plugin has dependencies that require a newer version of Jenkins. This PR should fix this warning by bumping the min Jenkins version to match min version in some dependencies.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
