### PR TITLE
fix: catch exception when converting report to utf-8

### DIFF
--- a/src/main/java/io/snyk/jenkins/SnykToHTML.java
+++ b/src/main/java/io/snyk/jenkins/SnykToHTML.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.util.Map;
+import java.nio.charset.MalformedInputException;
 
 import static io.snyk.jenkins.Utils.getURLSafeDateTime;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -58,19 +59,23 @@ public class SnykToHTML {
           .join();
       }
 
-      String stdout = stdoutPath.readToString();
-
-      if (LOG.isTraceEnabled()) {
-        LOG.trace("snyk-to-html command: {}", command);
-        LOG.trace("snyk-to-html exit code: {}", exitCode);
-        LOG.trace("snyk-to-html stdout: {}", stdout);
-      }
-
       if (exitCode != 0) {
         throw new RuntimeException("Exited with non-zero exit code. (Exit Code: " + exitCode + ")");
       }
 
-      stdoutPath.write(stdout, UTF_8.name());
+      try {
+        String stdout = stdoutPath.readToString();
+
+        if (LOG.isTraceEnabled()) {
+          LOG.trace("snyk-to-html command: {}", command);
+          LOG.trace("snyk-to-html exit code: {}", exitCode);
+          LOG.trace("snyk-to-html stdout: {}", stdout);
+        }
+
+        stdoutPath.write(stdout, UTF_8.name());
+      } catch(MalformedInputException e) {
+        logger.println("Couldn't convert report to UTF-8.");
+      }
 
       return stdoutPath;
     } catch (IOException | InterruptedException | RuntimeException ex) {


### PR DESCRIPTION
In some constellations generating the report might fail while converting to utf-8. This used to fail the pipeline which quite drastic. This PR will catch conversion errors and just go on.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```