### PR TITLE
chore: update pom dependency and base image to jenkins 2.442

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -12,11 +12,11 @@ RUN ./mvnw verify -q -s .mvn/settings.xml --fail-never
 COPY . .
 RUN ./mvnw clean verify -s .mvn/settings.xml
 
-FROM jenkins/jenkins:2.401.1-jdk11
+FROM jenkins/jenkins:2.442-jdk11
 
 USER root
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -qq git python3 python3-pip sudo
-RUN pip3 install virtualenv
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
+    apt-get install -qq --no-install-recommends git python3 python3-pip python3-virtualenv sudo
 
 USER jenkins
 

--- a/.github/run.sh
+++ b/.github/run.sh
@@ -8,5 +8,5 @@ echo "Please connect to IP address $HOST"
 # to persist data:
   # create a volume using docker `volume create <VOLUME_NAME>`
   # mount the volume via docker run command using `-v <VOLUME_NAME>:/var/jenkins_home`
-docker run -rm --platform linux/amd64 -p 8080:8080 -p 50000:50000 --name=jenkins-snyk jenkins-snyk
+docker run --rm --platform linux/amd64 -p 8080:8080 -p 50000:50000 --name=jenkins-snyk jenkins-snyk
 popd || exit

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <properties>
-    <jenkins.version>2.401.1</jenkins.version>
+    <jenkins.version>2.442</jenkins.version>
     <!-- java11 required since 2.357:
           https://www.jenkins.io/blog/2022/06/28/require-java-11/ -->
     <java.version>11</java.version>


### PR DESCRIPTION
Mitigate critical severity vuln
https://app.snyk.io/vuln/SNYK-JAVA-ORGJENKINSCIMAIN-6190606 by updating the pom dependency and base image to jenkins 2.442.

In this new base image, system-wide pip installs aren't allowed so the Debian packages are updated to satisfy the virtualenv requirement.

Installing Debian packages with --no-install-recommends because the default was pulling in x11 and a bunch of extra junk a Jenkins server shouldn't need.

Drive-by: fix docker command-line flag in run script, noticed this when testing the image locally.

### Testing done

Created a local Docker image with `./.github/build.sh`.

Ran it with `./.github/run.sh`.

Confirmed Snyk installed and executed.

https://snyksec.atlassian.net/browse/CLI-168

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
