### PR TITLE
chore: update pom dependency, base image to jenkins 2.450

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -12,7 +12,7 @@ RUN ./mvnw verify -q -s .mvn/settings.xml --fail-never
 COPY . .
 RUN ./mvnw clean verify -s .mvn/settings.xml
 
-FROM jenkins/jenkins:2.442-jdk11
+FROM jenkins/jenkins:2.450-jdk11
 
 USER root
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,13 +1,4 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
-  <mirrors>
-    <mirror>
-      <id>repo.jenkins-ci.org</id>
-      <name>Jenkins CI Proxy repository</name>
-      <url>https://repo.jenkins-ci.org/public/</url>
-      <mirrorOf>*</mirrorOf>
-    </mirror>
-  </mirrors>
-
   <servers>
     <server>
       <id>maven.jenkins-ci.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <properties>
-    <jenkins.version>2.442</jenkins.version>
+    <jenkins.version>2.450</jenkins.version>
     <!-- java11 required since 2.357:
           https://www.jenkins.io/blog/2022/06/28/require-java-11/ -->
     <java.version>11</java.version>


### PR DESCRIPTION
Mitigate several high severity vulns
- https://app.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-6457293
- https://app.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-6254296
- https://app.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-6261586
- https://app.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-6444790

Cleaned up unnecessary `mirror` configuration in `./mvn/settings.xml` causing dependency download to fail with dependency not found failures.

Testing done
- Created a local Docker image with `./.github/build.sh`
- Ran it with `./.github/run.sh`
- Confirmed local build of Snyk Security Scanner was installed
- Configured Snyk Security Scanner plugin
- Configured test repo (goof)
- Configured Snyk job for repo
- Ran job and verified Snyk worked