### PR TITLE
chore: use new download url for snyk downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ To see more information on your steps, you can increase logging and re-run your 
 
 ### Failed Installations
 
-By default, Snyk Installations will download Snyk's binaries over the network from `static.snyk.io`. If this fails there
+By default, Snyk Installations will download Snyk's binaries over the network from `downloads.snyk.io` and use `static.snyk.io` as a fallback. If this fails there
 may be a network or proxy issue. If you cannot fix the issue, you can use a [Manual Installation](#2-configure-a-snyk-installation) instead.
 
 ---

--- a/src/main/java/io/snyk/jenkins/tools/SnykInstaller.java
+++ b/src/main/java/io/snyk/jenkins/tools/SnykInstaller.java
@@ -88,34 +88,37 @@ public class SnykInstaller extends ToolInstaller {
   }
 
   private FilePath downloadSnykBinaries(FilePath expected, Node node) {
-    try {
-      LOG.info("Installing Snyk '{}' on Build Node '{}'", version, node.getDisplayName());
+    for (String snykUrlTemplate : DownloadService.SNYK_CLI_DOWNLOAD_URLS) {
+      try {
+        LOG.info("Installing Snyk '{}' on Build Node '{}'", version, node.getDisplayName());
 
-      final VirtualChannel nodeChannel = node.getChannel();
-      if (nodeChannel == null) {
-        throw new IOException(format("Build Node '%s' is offline.", node.getDisplayName()));
+        final VirtualChannel nodeChannel = node.getChannel();
+        if (nodeChannel == null) {
+          throw new IOException(format("Build Node '%s' is offline.", node.getDisplayName()));
+        }
+
+        Platform platform = PlatformItem.convert(this.platform);
+        if (platform == null) {
+          LOG.info("Installer architecture is not configured or use AUTO mode");
+          platform = nodeChannel.call(new GetPlatform());
+        }
+        LOG.info("Configured installer architecture is {}", platform);
+
+        URL snykDownloadUrl = DownloadService.constructDownloadUrlForSnyk(snykUrlTemplate, "cli", version, platform);
+        URL snykToHtmlDownloadUrl = DownloadService.constructDownloadUrlForSnyk(snykUrlTemplate, "snyk-to-html", "latest", platform);
+
+        expected.mkdirs();
+        nodeChannel.call(new Downloader(snykDownloadUrl, expected.child(platform.snykWrapperFileName)));
+        nodeChannel.call(new Downloader(snykToHtmlDownloadUrl, expected.child(platform.snykToHtmlWrapperFileName)));
+        expected.child(INSTALLED_FROM).write(snykDownloadUrl.toString(), UTF_8.name());
+        expected.child(TIMESTAMP_FILE).write(valueOf(Instant.now().toEpochMilli()), UTF_8.name());
+
+        return expected;
+      } catch (RuntimeException | IOException | InterruptedException ex) {
+        LOG.error("Failed to install Snyk.", ex);
       }
-
-      Platform platform = PlatformItem.convert(this.platform);
-      if (platform == null) {
-        LOG.info("Installer architecture is not configured or use AUTO mode");
-        platform = nodeChannel.call(new GetPlatform());
-      }
-      LOG.info("Configured installer architecture is {}", platform);
-
-      URL snykDownloadUrl = DownloadService.getDownloadUrlForSnyk(version, platform);
-      URL snykToHtmlDownloadUrl = DownloadService.getDownloadUrlForSnykToHtml("latest", platform);
-
-      expected.mkdirs();
-      nodeChannel.call(new Downloader(snykDownloadUrl, expected.child(platform.snykWrapperFileName)));
-      nodeChannel.call(new Downloader(snykToHtmlDownloadUrl, expected.child(platform.snykToHtmlWrapperFileName)));
-      expected.child(INSTALLED_FROM).write(snykDownloadUrl.toString(), UTF_8.name());
-      expected.child(TIMESTAMP_FILE).write(valueOf(Instant.now().toEpochMilli()), UTF_8.name());
-
-      return expected;
-    } catch (RuntimeException | IOException | InterruptedException ex) {
-      throw new RuntimeException("Failed to install Snyk.", ex);
     }
+    throw new RuntimeException("Failed to install Snyk.");
   }
 
   @SuppressWarnings("unused")

--- a/src/main/java/io/snyk/jenkins/tools/SnykInstaller.java
+++ b/src/main/java/io/snyk/jenkins/tools/SnykInstaller.java
@@ -107,6 +107,9 @@ public class SnykInstaller extends ToolInstaller {
         URL snykDownloadUrl = DownloadService.constructDownloadUrlForSnyk(snykUrlTemplate, "cli", version, platform);
         URL snykToHtmlDownloadUrl = DownloadService.constructDownloadUrlForSnyk(snykUrlTemplate, "snyk-to-html", "latest", platform);
 
+        LOG.info("Downloading CLI from {}", snykDownloadUrl);
+        LOG.info("Downloading snyk-to-html from {}", snykToHtmlDownloadUrl);
+
         expected.mkdirs();
         nodeChannel.call(new Downloader(snykDownloadUrl, expected.child(platform.snykWrapperFileName)));
         nodeChannel.call(new Downloader(snykToHtmlDownloadUrl, expected.child(platform.snykToHtmlWrapperFileName)));

--- a/src/main/java/io/snyk/jenkins/tools/internal/DownloadService.java
+++ b/src/main/java/io/snyk/jenkins/tools/internal/DownloadService.java
@@ -5,20 +5,24 @@ import io.snyk.jenkins.tools.Platform;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import static java.lang.String.format;
 
 public class DownloadService {
+  public static final String SNYK_INTEGRATION_NAME = "JENKINS_PLUGIN";
+  private static final String SNYK_DOWNLOAD_PRIMARY = "https://downloads.snyk.io/%s/%s/%s";
+  private static final String SNYK_DOWNLOAD_SECONDARY = "https://static.snyk.io/%s/%s/%s";
+  public static final List<String> SNYK_CLI_DOWNLOAD_URLS = Collections.unmodifiableList(Arrays.asList(SNYK_DOWNLOAD_PRIMARY, SNYK_DOWNLOAD_SECONDARY));
 
   private DownloadService() {
     // squid:S1118
   }
 
-  public static URL getDownloadUrlForSnyk(@Nonnull String version, @Nonnull Platform platform) throws IOException {
-    return new URL(format("https://static.snyk.io/cli/%s/%s", version, platform.snykWrapperFileName));
-  }
-
-  public static URL getDownloadUrlForSnykToHtml(@Nonnull String version, @Nonnull Platform platform) throws IOException {
-    return new URL(format("https://static.snyk.io/snyk-to-html/%s/%s", version, platform.snykToHtmlWrapperFileName));
+  public static URL constructDownloadUrlForSnyk(@Nonnull String urlTemplate, @Nonnull String product, @Nonnull String version, @Nonnull Platform platform) throws IOException {
+    URL urlNoUtm = new URL(format(urlTemplate, product, version, platform.snykWrapperFileName));
+    return new URL(urlNoUtm.toString() + "?utm_source=" + SNYK_INTEGRATION_NAME);
   }
 }

--- a/src/main/java/io/snyk/jenkins/tools/internal/DownloadService.java
+++ b/src/main/java/io/snyk/jenkins/tools/internal/DownloadService.java
@@ -12,9 +12,9 @@ import java.util.List;
 import static java.lang.String.format;
 
 public class DownloadService {
-  public static final String SNYK_INTEGRATION_NAME = "JENKINS_PLUGIN";
   private static final String SNYK_DOWNLOAD_PRIMARY = "https://downloads.snyk.io/%s/%s/%s";
   private static final String SNYK_DOWNLOAD_SECONDARY = "https://static.snyk.io/%s/%s/%s";
+  public static final String SNYK_INTEGRATION_NAME = "JENKINS_PLUGIN";
   public static final List<String> SNYK_CLI_DOWNLOAD_URLS = Collections.unmodifiableList(Arrays.asList(SNYK_DOWNLOAD_PRIMARY, SNYK_DOWNLOAD_SECONDARY));
 
   private DownloadService() {
@@ -22,7 +22,13 @@ public class DownloadService {
   }
 
   public static URL constructDownloadUrlForSnyk(@Nonnull String urlTemplate, @Nonnull String product, @Nonnull String version, @Nonnull Platform platform) throws IOException {
-    URL urlNoUtm = new URL(format(urlTemplate, product, version, platform.snykWrapperFileName));
+    URL urlNoUtm;
+
+    if (product.equals("cli")) {
+      urlNoUtm = new URL(format(urlTemplate, product, version, platform.snykWrapperFileName));
+    } else { // snyk-to-html
+      urlNoUtm = new URL(format(urlTemplate, product, version, platform.snykToHtmlWrapperFileName));
+    }
     return new URL(urlNoUtm.toString() + "?utm_source=" + SNYK_INTEGRATION_NAME);
   }
 }

--- a/src/main/java/io/snyk/jenkins/tools/internal/DownloadService.java
+++ b/src/main/java/io/snyk/jenkins/tools/internal/DownloadService.java
@@ -1,5 +1,6 @@
 package io.snyk.jenkins.tools.internal;
 
+import io.snyk.jenkins.PluginMetadata;
 import io.snyk.jenkins.tools.Platform;
 
 import javax.annotation.Nonnull;
@@ -14,7 +15,6 @@ import static java.lang.String.format;
 public class DownloadService {
   private static final String SNYK_DOWNLOAD_PRIMARY = "https://downloads.snyk.io/%s/%s/%s";
   private static final String SNYK_DOWNLOAD_SECONDARY = "https://static.snyk.io/%s/%s/%s";
-  public static final String SNYK_INTEGRATION_NAME = "JENKINS_PLUGIN";
   public static final List<String> SNYK_CLI_DOWNLOAD_URLS = Collections.unmodifiableList(Arrays.asList(SNYK_DOWNLOAD_PRIMARY, SNYK_DOWNLOAD_SECONDARY));
 
   private DownloadService() {
@@ -29,6 +29,6 @@ public class DownloadService {
     } else { // snyk-to-html
       urlNoUtm = new URL(format(urlTemplate, product, version, platform.snykToHtmlWrapperFileName));
     }
-    return new URL(urlNoUtm.toString() + "?utm_source=" + SNYK_INTEGRATION_NAME);
+    return new URL(urlNoUtm.toString() + "?utm_source=" + PluginMetadata.getIntegrationName());
   }
 }

--- a/src/test/java/io/snyk/jenkins/tools/internal/DownloadServiceTest.java
+++ b/src/test/java/io/snyk/jenkins/tools/internal/DownloadServiceTest.java
@@ -1,0 +1,46 @@
+package io.snyk.jenkins.tools.internal;
+
+import org.junit.Test;
+
+import io.snyk.jenkins.tools.Platform;
+
+import java.io.IOException;
+import java.net.URL;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNull.notNullValue;
+
+
+public class DownloadServiceTest {
+
+  @Test
+  public void constructDownloadUrlForSnyk_shouldReturnExpectedUrlForCli() throws IOException {
+    String urlTemplate = "https://downloads.snyk.io/%s/%s/%s";
+    String product = "cli";
+    String version = "stable";
+    String queryParam = "?utm_source=" + DownloadService.SNYK_INTEGRATION_NAME;
+    Platform platform = Platform.MAC_OS;
+
+    URL expectedUrl = new URL("https://downloads.snyk.io/" + product + "/" + version + "/" + "snyk-macos" + queryParam);
+    URL actualUrl = DownloadService.constructDownloadUrlForSnyk(urlTemplate, product, version, platform);
+
+    assertThat(actualUrl, notNullValue());
+    assertThat(actualUrl, equalTo(expectedUrl));
+  }
+
+  @Test
+  public void constructDownloadUrlForSnyk_shouldReturnExpectedUrlForSnykToHtml() throws IOException {
+    String urlTemplate = "https://downloads.snyk.io/%s/%s/%s";
+    String product = "snyk-to-html";
+    String version = "stable";
+    String queryParam = "?utm_source=" + DownloadService.SNYK_INTEGRATION_NAME;
+    Platform platform = Platform.MAC_OS;
+
+    URL expectedUrl = new URL("https://downloads.snyk.io/" + product + "/" + version + "/" + "snyk-to-html-macos" + queryParam);
+    URL actualUrl = DownloadService.constructDownloadUrlForSnyk(urlTemplate, product, version, platform);
+
+    assertThat(actualUrl, notNullValue());
+    assertThat(actualUrl, equalTo(expectedUrl));
+  }
+}

--- a/src/test/java/io/snyk/jenkins/tools/internal/DownloadServiceTest.java
+++ b/src/test/java/io/snyk/jenkins/tools/internal/DownloadServiceTest.java
@@ -1,5 +1,6 @@
 package io.snyk.jenkins.tools.internal;
 
+import io.snyk.jenkins.PluginMetadata;
 import org.junit.Test;
 
 import io.snyk.jenkins.tools.Platform;
@@ -19,7 +20,7 @@ public class DownloadServiceTest {
     String urlTemplate = "https://downloads.snyk.io/%s/%s/%s";
     String product = "cli";
     String version = "stable";
-    String queryParam = "?utm_source=" + DownloadService.SNYK_INTEGRATION_NAME;
+    String queryParam = "?utm_source=" + PluginMetadata.getIntegrationName();
     Platform platform = Platform.MAC_OS;
 
     URL expectedUrl = new URL("https://downloads.snyk.io/" + product + "/" + version + "/" + "snyk-macos" + queryParam);
@@ -34,7 +35,7 @@ public class DownloadServiceTest {
     String urlTemplate = "https://downloads.snyk.io/%s/%s/%s";
     String product = "snyk-to-html";
     String version = "stable";
-    String queryParam = "?utm_source=" + DownloadService.SNYK_INTEGRATION_NAME;
+    String queryParam = "?utm_source=" + PluginMetadata.getIntegrationName();
     Platform platform = Platform.MAC_OS;
 
     URL expectedUrl = new URL("https://downloads.snyk.io/" + product + "/" + version + "/" + "snyk-to-html-macos" + queryParam);


### PR DESCRIPTION
Updates the Snyk CLI and snyk-to-html download URLs, will fallback to original download URL if the new one fails.

**Testing done**

Created a local Docker image with ./.github/build.sh
- Ran it with ./.github/run.sh
- Confirmed local build of Snyk Security Scanner was installed
- Configured Snyk Security Scanner plugin
- Configured test repo (goof)
- Configured Snyk job for repo
- Ran job and verified Snyk worked
